### PR TITLE
Develop

### DIFF
--- a/src/utility/Speaker_Class.hpp
+++ b/src/utility/Speaker_Class.hpp
@@ -77,12 +77,16 @@ namespace m5
 
     /// now in playing or not.
     /// @return false=not playing / true=playing
-    bool isPlaying(void) const volatile { return _play_channel_bits ? true : false; }
+    bool isPlaying(void) const volatile { return _play_channel_bits.load(); }
 
     /// now in playing or not.
     /// @param channel virtual channel number. (0~7), (default = automatically selected)
     /// @return 0=not playing / 1=playing (There's room in the queue) / 2=playing (There's no room in the queue.)
     size_t isPlaying(uint8_t channel) const volatile { return (channel < sound_channel_max) ? ((bool)_ch_info[channel].wavinfo[0].repeat) + ((bool)_ch_info[channel].wavinfo[1].repeat) : 0; }
+
+    /// Get the number of channels that are playing.
+    /// @return number of channels that are playing.
+    size_t getPlayingChannels(void) const volatile { return __builtin_popcount(_play_channel_bits.load()); }
 
     /// sets the output master volume of the sound.
     /// @param master_volume master volume (0~255)


### PR DESCRIPTION
Thank you for AquesTalk example of asynchronous version!
I tried it and it works fine. But when I applied it for my project using wifi UDP function, it doesn't work well because the AquesTalk task was set on the same core of esp32 (PRO_CPU_NUM = core0) as the wifi task.

xTaskCreate function is not for dual core esp32. So it always sets task on core0.
When there is some network function, the task runs on PRO_CPU_NUM (= core 0).
In this situation, it's better for the other function like AquesTalk to be set on APP_CPU_NUM (= core 1).

xTaskCreateUniversal has upward compatibility of xTaskCreate, it can set a task on each core like xTaskCreatePinnedToCore.

I changed xTask from xTaskCreate to xTaskCreateUniversal so that it sets task on core1.
It works fine on a program with wifi function like my project.