### PR TITLE
improve sync status check method in rtc example

### DIFF
--- a/examples/Basic/Rtc/Rtc.ino
+++ b/examples/Basic/Rtc/Rtc.ino
@@ -50,14 +50,14 @@ void setup(void)
   Serial.println("\r\n WiFi Connected.");
 
   time_t t;
-  while ((t = time(nullptr)) < 65536)
+  while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET)
   {
     Serial.print('.');
-    delay(500);
+    delay(1000);
   }
   Serial.println("\r\n NTP Connected.");
 
-  t++; // Advance one second.
+  t = time(nullptr)+1; // Advance one second.
   while (t > time(nullptr));  /// Synchronization in seconds
   M5.Rtc.setDateTime( localtime( &t ) );
 


### PR DESCRIPTION
In my circumstance (M5STACK CORE2 connecting to home wifi), 
even after coming out from `while ((t = time(nullptr)) < 65536)` loop, time update is not completed yet.
Adding some `delay` after while loop is one solution, but using `sntp_get_sync_status()` is better.

[API Reference by espressif](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/system_time.html#_CPPv420sntp_get_sync_statusv)