### PR TITLE
PDM only support on I2S0, use I2S0 as default

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -470,7 +470,6 @@ for (int i = 0; i < 0x50; ++i)
       auto mic_cfg = Mic.config();
 
       mic_cfg.over_sampling = 2;
-      mic_cfg.i2s_port = I2S_NUM_1;
       switch (_board)
       {
 #if defined (CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
See [here](https://github.com/espressif/esp-idf/blob/master/components/driver/i2s/i2s_pdm.c#L158)