### PR TITLE
Force UTC before calling `mktime(3)`

### DIFF
--- a/src/utility/RTC8563_Class.cpp
+++ b/src/utility/RTC8563_Class.cpp
@@ -4,6 +4,7 @@
 #include "RTC8563_Class.hpp"
 
 #include <sys/time.h>
+#include <stdlib.h>
 
 namespace m5
 {
@@ -267,7 +268,17 @@ namespace m5
       t_st.tm_min  = dt.time.minutes;
       t_st.tm_sec  = dt.time.seconds;
       timeval now;
+      // mktime(3) uses localtime, force UTC
+      char *oldtz = getenv("TZ");
+      setenv("TZ", "GMT0", 1);
+      tzset(); // Workaround for https://github.com/espressif/esp-idf/issues/11455
       now.tv_sec = mktime(&t_st);
+      if (oldtz)
+      {
+        setenv("TZ", oldtz, 1);
+      } else {
+        unsetenv("TZ");
+      }
       now.tv_usec = 0;
       settimeofday(&now, tz);
     }


### PR DESCRIPTION
Fix a bug where the system time is synchronized from localtime instead of UTC. ESP-IDF mostly considers system time is UTC and ignores timezone argument of settimeofday.

The fix is not thread safe, as is any write access to TZ environment variable.

On a side note, ESP-IDF doesn't seem to have a UTC equivalent of mktime(3) such as GNU/BSD extension timegm(3).