### PR TITLE
Add cast to _batAdc in Power_Class.cpp

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -81,7 +81,7 @@ namespace m5
       m5gfx::gpio_hi(TimerCam_POWER_HOLD_PIN);
       m5gfx::pinMode(TimerCam_LED_PIN, m5gfx::pin_mode_t::output);
       m5gfx::gpio_lo(TimerCam_LED_PIN);  // system LED off
-      _batAdc = ADC1_GPIO38_CHANNEL;
+      _batAdc = (adc1_channel_t) ADC1_GPIO38_CHANNEL;
       _pmic = pmic_t::pmic_adc;
       _adc_ratio = 1.513f;
       break;
@@ -89,7 +89,7 @@ namespace m5
     case board_t::board_M5StackCoreInk:
       _pwrHoldPin = CoreInk_POWER_HOLD_PIN;
       _wakeupPin = GPIO_NUM_27; // power button;
-      _batAdc = ADC1_GPIO35_CHANNEL;
+      _batAdc = (adc1_channel_t) ADC1_GPIO35_CHANNEL;
       _pmic = pmic_t::pmic_adc;
       _adc_ratio = 25.1f / 5.1f;
       break;
@@ -98,7 +98,7 @@ namespace m5
       _pwrHoldPin = M5Paper_POWER_HOLD_PIN;
       m5gfx::pinMode(M5Paper_EXT5V_ENABLE_PIN, m5gfx::pin_mode_t::output);
       _wakeupPin = GPIO_NUM_36; // touch panel INT;
-      _batAdc = ADC1_GPIO35_CHANNEL;
+      _batAdc = (adc1_channel_t) ADC1_GPIO35_CHANNEL;
       _pmic = pmic_t::pmic_adc;
       _adc_ratio = 2.0f;
       break;


### PR DESCRIPTION
I had troubles compiling when using M5Unified with platformio without an explicit cast from 'int' to 'adc_channel_t.

```
In file included from .pio/libdeps/m5stack-core-esp32/M5Unified/src/utility/Power_Class.cpp:24:
.pio/libdeps/m5stack-core-esp32/M5Unified/src/utility/Power_Class.cpp: In member function 'bool m5::Power_Class::begin()':
/home/marcel/.platformio/packages/framework-espidf/components/soc/esp32/include/soc/adc_channel.h:15:33: error: invalid conversion from 'int' to 'adc1_channel_t' [-fpermissive]
   15 | #define ADC1_GPIO38_CHANNEL     2
      |                                 ^
      |                                 |
      |                                 int
.pio/libdeps/m5stack-core-esp32/M5Unified/src/utility/Power_Class.cpp:84:18: note: in expansion of macro 'ADC1_GPIO38_CHANNEL'
   84 |       _batAdc =  ADC1_GPIO38_CHANNEL;
      |                  ^~~~~~~~~~~~~~~~~~~
*** [.pio/build/m5stack-core-esp32/libc7a/M5Unified/utility/Power_Class.o] Error 1
```


Adding this explicit cast resolves the issue.