### PR TITLE
Update Power_Class.cpp

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -629,6 +629,10 @@ namespace m5
 
       case pmic_t::pmic_unknown:
       default:
+        if(_rtcIntPin == GPIO_NUM_MAX && _wakeupPin < GPIO_NUM_MAX)
+        {
+          esp_sleep_enable_ext0_wakeup((gpio_num_t)_wakeupPin, false);
+        }
         break;
       }
     }


### PR DESCRIPTION
M5StickC Plus2でUSB接続中にpowerOffした場合には主電源が切れずにスリープモードになる。 
しかしながら、そこからの復帰がUSB接続をやめて、6秒以上電源ボタンをおして強制電源OFFしかなくなるので電源ボタンでの復帰を追加する

バッテリー駆動中や、PMICがある機種の場合には主電源が切れるため、スリープモードでの復帰追加コストはほとんどないと考えられる