### PR TITLE
Log_Class dump で uintptr_t が 32 bit を超える環境下(native 等) で警告が出る

### DIFF
--- a/src/utility/Log_Class.cpp
+++ b/src/utility/Log_Class.cpp
@@ -133,7 +133,7 @@ namespace m5
     auto addr = reinterpret_cast<uint32_t*>((uintptr_t)a & ~0x03);
     char buf[84];
     do {
-      int pos = snprintf(buf, sizeof(buf), "0x%08x|", (uintptr_t)addr);
+      int pos = snprintf(buf, sizeof(buf), "0x%08" PRIxPTR "|", (uintptr_t)addr);
       // printf("0x%08x|", (uintptr_t)addr);
       int l = len > 4 ? 4 : len;
       for (int i = 0; i < l; ++i) {


### PR DESCRIPTION
uintptr_t のサイズは環境依存なので、 汎用的なフォーマット文字列に修正しました。

`-Werror=format` でコンパイルした場合、これが原因でエラー扱いとなります。