### PR TITLE
fix(tab5): Enable WiFi power via I/O expander initialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`src/` hosts the ESP-IDF/Arduino component entry (`M5Unified.cpp/.hpp`) plus hardware-specific helpers under `src/utility/{imu,led,power,rtc}`. `examples/Basic/` and `examples/Advanced/` are Arduino sketches grouped by feature, while `examples/PlatformIO_SDL` is a native SDL harness whose `platformio.ini` pulls this repo in via `lib_extra_dirs`. Build metadata lives in `CMakeLists.txt`, `component.mk`, `library.json`, and `library.properties`, with supporting schematics in `docs/img`.
+
+## Build, Test, and Development Commands
+- `platformio run -d examples/PlatformIO_SDL -e native` verifies the SDL host harness compiles against the root library; use the `native_…` envs to cover each board flag.
+- `platformio run -d examples/PlatformIO_SDL -e esp32_arduino` (or `esp32c3_arduino`, `esp32s3_arduino`) checks Arduino-framework builds for each chip line defined in `platformio.ini`.
+- `platformio run -d examples/PlatformIO_SDL -e esp32_idf` exercises the ESP-IDF flow through PlatformIO so its `CMakeLists.txt`/`component.mk` paths stay valid.
+- Use `arduino-cli compile --fqbn <board> examples/Basic/<ExampleName>` when updating a sketch to keep IDE consumers happy.
+- Once installed as an IDF component, run `idf.py build` from your ESP-IDF project to confirm the component links.
+
+## Coding Style & Naming Conventions
+Keep ANSI C++ style consistent: braces on their own lines, four-space indentation, and brief `//` comments for complex mappings. Classes/structs follow `CamelCase`, helper enums use `board_t::board_*`, and macros remain uppercase (`CONFIG_*`, `NON_BREAK`). Match the existing casing when adding new `utility/` helpers or board constants, and prefer member functions in `PascalCase` when mirroring the `M5Unified` API.
+
+## Testing Guidelines
+No automated suite exists—testing means building sketches and hardware examples. Treat each example folder as a test target (e.g., `HowToUse`, `Button`, `Speaker`), describe your manual steps in the PR, and if you add host assertions rerun `platformio test -d examples/PlatformIO_SDL -e native` after the build.
+
+## Commit & Pull Request Guidelines
+Adopt the existing `type(scope): summary` pattern (`fix(tab5): …`, `feat`, `chore`). Include the affected board or module in scope, mention related issues, and list the commands or hardware you used to verify the change in the PR description. When power/IMU/audio code changes, tag maintainers so they can confirm on the relevant device matrix.
+
+## Configuration & Dependency Tips
+Keep `library.json`/`library.properties` synced with the `M5GFX` version and bump `version` when releasing. Reference `examples/PlatformIO_SDL/platformio.ini` when adding new PlatformIO envs—just extend `esp32_base` and adjust `framework`/`board` overrides.

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1334,6 +1334,39 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     return board;
   }
 
+#if !defined (M5UNIFIED_PC_BUILD)
+namespace {
+  bool configure_tab5_ioexpander(PI4IOE5V6408_Class* ioexp, int index)
+  {
+    const uint8_t i2c_addr = 0x43 + index;
+    if (!ioexp->begin()) {
+      ESP_LOGW("M5Unified", "Tab5 I/O expander %d @ 0x%02x not detected, skipping", index, i2c_addr);
+      return false;
+    }
+
+    if (index == 0) {
+      // PI4IOE1 @ 0x43 - Display & peripherals
+      ioexp->writeRegister8(0x03, 0b01111111);  // Direction: P0-P6 output, P7 input
+      ioexp->writeRegister8(0x05, 0b01110110);  // Output: P1=SPK_EN, P2=EXT5V_EN, P4=LCD_RST, P5=TP_RST, P6=CAM_RST HIGH
+      ioexp->writeRegister8(0x07, 0b00000000);  // Disable high-impedance mode
+      ioexp->writeRegister8(0x0B, 0b01111111);  // Enable pull resistors
+      ioexp->writeRegister8(0x0D, 0b01111111);  // Pull-up (not pull-down)
+    } else {
+      // PI4IOE2 @ 0x44 - WiFi & power management
+      ioexp->writeRegister8(0x03, 0b10111001);  // Direction: P0,P3,P7 output, others input
+      ioexp->writeRegister8(0x05, 0b00001001);  // Output: P0=WLAN_PWR_EN (WiFi!), P3=USB5V_EN, P7=CHG_EN HIGH
+      ioexp->writeRegister8(0x07, 0b00000110);  // High-impedance for P1,P2
+      ioexp->writeRegister8(0x0B, 0b11111001);  // Enable pull resistors
+      ioexp->writeRegister8(0x0D, 0b10111001);  // Pull-up configuration
+      ioexp->writeRegister8(0x09, 0b01000000);  // P6 default high (USB-C detect)
+    }
+
+    ESP_LOGI("M5Unified", "Tab5 I/O expander %d @ 0x%02x configured", index, i2c_addr);
+    return true;
+  }
+}
+#endif
+
   void M5Unified::_setup_i2c(board_t board)
   {
 #if defined (M5UNIFIED_PC_BUILD)
@@ -1376,24 +1409,10 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       for (int i = 0; i < 2; ++i)
       {
         auto ioexp = new PI4IOE5V6408_Class(0x43 + i);
-        ioexp->begin();
-        
-        // Configure I/O expander pins for Tab5 peripherals
-        if (i == 0) {  // PI4IOE1 @ 0x43
-          ioexp->writeRegister8(0x03, 0b01111111);  // Direction: P0-P6 output, P7 input
-          ioexp->writeRegister8(0x05, 0b01110110);  // Output: P1=SPK_EN, P2=EXT5V_EN, P4=LCD_RST, P5=TP_RST, P6=CAM_RST HIGH
-          ioexp->writeRegister8(0x07, 0b00000000);  // Disable high-impedance mode
-          ioexp->writeRegister8(0x0B, 0b01111111);  // Enable pull resistors
-          ioexp->writeRegister8(0x0D, 0b01111111);  // Pull-up (not pull-down)
-        } else {  // PI4IOE2 @ 0x44
-          ioexp->writeRegister8(0x03, 0b10111001);  // Direction: P0,P3,P7 output, others input
-          ioexp->writeRegister8(0x05, 0b00001001);  // Output: P0=WLAN_PWR_EN (WiFi!), P3=USB5V_EN, P7=CHG_EN HIGH
-          ioexp->writeRegister8(0x07, 0b00000110);  // High-impedance for P1,P2
-          ioexp->writeRegister8(0x0B, 0b11111001);  // Enable pull resistors
-          ioexp->writeRegister8(0x0D, 0b10111001);  // Pull-up configuration
-          ioexp->writeRegister8(0x09, 0b01000000);  // P6 default high (USB-C detect)
+        if (!configure_tab5_ioexpander(ioexp, i)) {
+          delete ioexp;
+          continue;
         }
-        
         _io_expander[i].reset(ioexp);
       }
       break;
@@ -1409,34 +1428,10 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       for (int i = 0; i < 2; ++i)
       {
         auto ioexp = new PI4IOE5V6408_Class(0x43 + i);
-        
-        // Check if I/O expander chip is present
-        if (!ioexp->begin()) {
-          // Chip not responding - log and skip
-          // This handles future Tab5 variants without I/O expanders
-          ESP_LOGW("M5Unified", "Tab5 I/O expander %d @ 0x%02x not detected, skipping", i, 0x43 + i);
+        if (!configure_tab5_ioexpander(ioexp, i)) {
           delete ioexp;
           continue;
         }
-        
-        // Configure I/O expander pins for Tab5 peripherals
-        // Based on M5Stack official Tab5-UserDemo reference implementation
-        if (i == 0) {  // PI4IOE1 @ 0x43 - Display & peripherals
-          ioexp->writeRegister8(0x03, 0b01111111);  // Direction: P0-P6 output, P7 input
-          ioexp->writeRegister8(0x05, 0b01110110);  // Output: P1=SPK_EN, P2=EXT5V_EN, P4=LCD_RST, P5=TP_RST, P6=CAM_RST HIGH
-          ioexp->writeRegister8(0x07, 0b00000000);  // Disable high-impedance mode
-          ioexp->writeRegister8(0x0B, 0b01111111);  // Enable pull resistors
-          ioexp->writeRegister8(0x0D, 0b01111111);  // Pull-up (not pull-down)
-        } else {  // PI4IOE2 @ 0x44 - WiFi & power management
-          ioexp->writeRegister8(0x03, 0b10111001);  // Direction: P0,P3,P7 output, others input
-          ioexp->writeRegister8(0x05, 0b00001001);  // Output: P0=WLAN_PWR_EN (WiFi!), P3=USB5V_EN, P7=CHG_EN HIGH
-          ioexp->writeRegister8(0x07, 0b00000110);  // High-impedance for P1,P2
-          ioexp->writeRegister8(0x0B, 0b11111001);  // Enable pull resistors
-          ioexp->writeRegister8(0x0D, 0b10111001);  // Pull-up configuration
-          ioexp->writeRegister8(0x09, 0b01000000);  // P6 default high (USB-C detect)
-        }
-        
-        ESP_LOGI("M5Unified", "Tab5 I/O expander %d @ 0x%02x configured", i, 0x43 + i);
         _io_expander[i].reset(ioexp);
       }
       break;

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1377,6 +1377,23 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       {
         auto ioexp = new PI4IOE5V6408_Class(0x43 + i);
         ioexp->begin();
+        
+        // Configure I/O expander pins for Tab5 peripherals
+        if (i == 0) {  // PI4IOE1 @ 0x43
+          ioexp->writeRegister8(0x03, 0b01111111);  // Direction: P0-P6 output, P7 input
+          ioexp->writeRegister8(0x05, 0b01110110);  // Output: P1=SPK_EN, P2=EXT5V_EN, P4=LCD_RST, P5=TP_RST, P6=CAM_RST HIGH
+          ioexp->writeRegister8(0x07, 0b00000000);  // Disable high-impedance mode
+          ioexp->writeRegister8(0x0B, 0b01111111);  // Enable pull resistors
+          ioexp->writeRegister8(0x0D, 0b01111111);  // Pull-up (not pull-down)
+        } else {  // PI4IOE2 @ 0x44
+          ioexp->writeRegister8(0x03, 0b10111001);  // Direction: P0,P3,P7 output, others input
+          ioexp->writeRegister8(0x05, 0b00001001);  // Output: P0=WLAN_PWR_EN (WiFi!), P3=USB5V_EN, P7=CHG_EN HIGH
+          ioexp->writeRegister8(0x07, 0b00000110);  // High-impedance for P1,P2
+          ioexp->writeRegister8(0x0B, 0b11111001);  // Enable pull resistors
+          ioexp->writeRegister8(0x0D, 0b10111001);  // Pull-up configuration
+          ioexp->writeRegister8(0x09, 0b01000000);  // P6 default high (USB-C detect)
+        }
+        
         _io_expander[i].reset(ioexp);
       }
       break;
@@ -1392,7 +1409,34 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       for (int i = 0; i < 2; ++i)
       {
         auto ioexp = new PI4IOE5V6408_Class(0x43 + i);
-        ioexp->begin();
+        
+        // Check if I/O expander chip is present
+        if (!ioexp->begin()) {
+          // Chip not responding - log and skip
+          // This handles future Tab5 variants without I/O expanders
+          ESP_LOGW("M5Unified", "Tab5 I/O expander %d @ 0x%02x not detected, skipping", i, 0x43 + i);
+          delete ioexp;
+          continue;
+        }
+        
+        // Configure I/O expander pins for Tab5 peripherals
+        // Based on M5Stack official Tab5-UserDemo reference implementation
+        if (i == 0) {  // PI4IOE1 @ 0x43 - Display & peripherals
+          ioexp->writeRegister8(0x03, 0b01111111);  // Direction: P0-P6 output, P7 input
+          ioexp->writeRegister8(0x05, 0b01110110);  // Output: P1=SPK_EN, P2=EXT5V_EN, P4=LCD_RST, P5=TP_RST, P6=CAM_RST HIGH
+          ioexp->writeRegister8(0x07, 0b00000000);  // Disable high-impedance mode
+          ioexp->writeRegister8(0x0B, 0b01111111);  // Enable pull resistors
+          ioexp->writeRegister8(0x0D, 0b01111111);  // Pull-up (not pull-down)
+        } else {  // PI4IOE2 @ 0x44 - WiFi & power management
+          ioexp->writeRegister8(0x03, 0b10111001);  // Direction: P0,P3,P7 output, others input
+          ioexp->writeRegister8(0x05, 0b00001001);  // Output: P0=WLAN_PWR_EN (WiFi!), P3=USB5V_EN, P7=CHG_EN HIGH
+          ioexp->writeRegister8(0x07, 0b00000110);  // High-impedance for P1,P2
+          ioexp->writeRegister8(0x0B, 0b11111001);  // Enable pull resistors
+          ioexp->writeRegister8(0x0D, 0b10111001);  // Pull-up configuration
+          ioexp->writeRegister8(0x09, 0b01000000);  // P6 default high (USB-C detect)
+        }
+        
+        ESP_LOGI("M5Unified", "Tab5 I/O expander %d @ 0x%02x configured", i, 0x43 + i);
         _io_expander[i].reset(ioexp);
       }
       break;


### PR DESCRIPTION
Configure PI4IOE5V6408 I/O expanders (0x43, 0x44) with proper pin directions and output values for M5Stack Tab5 board peripherals.

Critical change: Enable WiFi power (P0 on PI4IOE2 @ 0x44) during board initialization. Without this, the ESP32-C6 WiFi module has no power and cannot respond to SDIO init commands, causing crash.

Configuration based on M5Stack official Tab5-UserDemo reference code.

PI4IOE1 @ 0x43:
- P1: SPK_EN (Speaker enable)
- P2: EXT5V_EN (External 5V enable)
- P4: LCD_RST (LCD reset)
- P5: TP_RST (Touch panel reset)
- P6: CAM_RST (Camera reset)

PI4IOE2 @ 0x44:
- P0: WLAN_PWR_EN (WiFi power enable) ← Critical for WiFi!
- P3: USB5V_EN (USB 5V enable)
- P4: Poweroff signal
- P6: USB-C detect (input)
- P7: CHG_EN (Charge enable)

Fixes WiFi crash with error:
  E (2788) sdmmc_common: sdmmc_init_ocr: send_op_cond (1) returned 0x107 E (2788) sdio_wrapper: sdmmc_card_init failed FreeRTOS: FreeRTOS Task "sdio_read" should not return, Aborting now