### PR TITLE
M5StickS3: fix power button

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1549,6 +1549,11 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       /// Slightly lengthen the acceptance time of the AXP192 power button multiclick.
       BtnPWR.setHoldThresh(BtnPWR.getHoldThresh() * 1.2);
     }
+    if (pmic_type == Power_Class::pmic_t::pmic_m5pm1)
+    {
+      _use_pmic_button = cfg.pmic_button;
+      Power.setSingleResetDisable(_use_pmic_button);
+    }
 
     if (cfg.clear_display)
     {
@@ -2614,7 +2619,15 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     }
 
 #if defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S3)
-    if (_use_pmic_button)
+
+    if ((_use_pmic_button) && (_board == board_t::board_M5StickS3))
+    {
+      bool b = false;
+      uint8_t ks = Power.getKeyState();
+      if(ks == 2) b = true;
+      BtnPWR.setRawState(ms, b);
+    }
+    if ((_use_pmic_button) && (_board != board_t::board_M5StickS3))
     {
       Button_Class::button_state_t state = Button_Class::button_state_t::state_nochange;
       bool read_axp = (ms - BtnPWR.getUpdateMsec()) >= BTNPWR_MIN_UPDATE_MSEC;

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1877,6 +1877,13 @@ namespace m5
 
     case pmic_t::pmic_py32pmic:
       return PY32pmic.getPekPress();
+
+    case pmic_t::pmic_m5pm1:
+    {
+      uint8_t reg_val = M5.In_I2C.readRegister8(m5pm1_i2c_addr, 0x48, i2c_freq);
+      return(reg_val & 1) ? 2 : 0;
+    }
+
 #endif
 
 #endif
@@ -1924,6 +1931,24 @@ namespace m5
 
         default:
           break;
+      }
+    }
+#endif
+  }
+
+  void Power_Class::setSingleResetDisable(bool disable)
+  {
+#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32S3)
+    if (M5.getBoard() == board_t::board_M5StickS3)
+    {
+      if (_pmic == pmic_t::pmic_m5pm1)
+      {
+        uint8_t reg_val = M5.In_I2C.readRegister8(m5pm1_i2c_addr, 0x49, i2c_freq);
+
+        if (disable) reg_val |= 0x01;
+        else reg_val &= ~0x01;
+
+        M5.In_I2C.writeRegister8(m5pm1_i2c_addr, 0x49, reg_val, i2c_freq);
       }
     }
 #endif

--- a/src/utility/Power_Class.hpp
+++ b/src/utility/Power_Class.hpp
@@ -203,6 +203,11 @@ namespace m5
     /// @param level Vibration strength of the motor. (0=stop)
     void setVibration(uint8_t level);
 
+    /// Set power button as reset
+    /// @param disable true=disable / false=enable
+    /// @attention use to configure power button (M5StickS3 only)
+    void setSingleResetDisable(bool disable);
+
     pmic_t getType(void) const { return _pmic; }
 
 #if defined (CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
Allow M5StickS3 power button to act as user button (instead of resetting the device).

This can be controlled by setting `cfg.pmic_button = true/false`.