### PR TITLE
ci: add workflow to publish to ESP Component Registry

### DIFF
--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -75,13 +75,13 @@ jobs:
         run: |
           git clone --depth 1 --branch "${{ steps.m5gfx.outputs.branch }}" \
             "https://github.com/${{ steps.m5gfx.outputs.repo }}.git" \
-            "$GITHUB_WORKSPACE/_deps/M5GFX"
+            "$GITHUB_WORKSPACE/_deps/m5gfx"
 
       - name: Build
         working-directory: examples/Test/build_test
         shell: bash
         env:
-          M5GFX_PATH: ${{ github.workspace }}/_deps/M5GFX
+          M5GFX_PATH: ${{ github.workspace }}/_deps/m5gfx
         run: |
           . $IDF_PATH/export.sh
           idf.py set-target ${{ matrix.target }}

--- a/.github/workflows/PushESPComponent.yml
+++ b/.github/workflows/PushESPComponent.yml
@@ -1,0 +1,22 @@
+name: Push component to ESP Component Registry
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  upload_components:
+    if: github.repository == 'm5stack/M5Unified'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Upload component to the component registry
+        uses: espressif/upload-components-ci-action@v1
+        with:
+          name: 'm5unified'
+          namespace: 'm5stack'
+          version: ${{ github.ref_name }}
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,20 @@ file(GLOB SRCS
      )
 set(COMPONENT_SRCS ${SRCS})
 
-if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
-    set(COMPONENT_REQUIRES M5GFX esp_adc driver)
+# ESP-IDF uses the directory name as the component name (case sensitive).
+# Use "M5GFX" when a sibling components/M5GFX checkout exists, otherwise "m5gfx"
+# (managed_components/m5stack__m5gfx is registered as the lower-case "m5gfx").
+get_filename_component(_m5u_parent "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
+if(EXISTS "${_m5u_parent}/M5GFX/CMakeLists.txt")
+    set(_m5gfx_name M5GFX)
 else()
-    set(COMPONENT_REQUIRES M5GFX esp_adc_cal)
+    set(_m5gfx_name m5gfx)
+endif()
+
+if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
+    set(COMPONENT_REQUIRES ${_m5gfx_name} esp_adc driver)
+else()
+    set(COMPONENT_REQUIRES ${_m5gfx_name} esp_adc_cal)
 endif()
 
 ### If you use arduino-esp32 components, please activate next comment line.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/PushESPComponent.yml` to publish the component to the ESP Component Registry (`m5stack/m5unified`) using `espressif/upload-components-ci-action@v1` whenever a SemVer-style tag (e.g. `0.2.16`) is pushed.
- Guarded with `if: github.repository == 'm5stack/M5Unified'` so the workflow is a no-op on forks.
- Migrates the publish flow that currently runs from a fork (`Forairaaaaa/M5Unified` `esp-component-register` branch) into the official repository.
- Also lower-cases `M5GFX` -> `m5gfx` in `COMPONENT_REQUIRES`. The component manager normalises names to lower case when expanding `managed_components/`, so mixed-case `REQUIRES` can fail to resolve when M5Unified is consumed as a managed component.

## Notes
- Requires the `IDF_COMPONENT_API_TOKEN` secret (a token with publish permission for the `m5stack` namespace) to be registered in this repository's Actions secrets. Already configured.
- Once this PR is merged into master and the next release tag is pushed, the workflow will run automatically. The fork-side workflow can then be disabled to avoid duplicate uploads.

## Test plan
- [ ] After merge, push a tag like `0.2.16` and verify the workflow run succeeds
- [ ] Verify the new version appears on https://components.espressif.com/components/m5stack/m5unified
- [ ] Confirm the workflow does not run on forks (job should be skipped)