### PR TITLE
Rename PY32PMIC class to M5PM1

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1084,7 +1084,7 @@ namespace m5
 
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
       case pmic_t::pmic_py32pmic:
-        PY32pmic.powerOff();
+        M5pm1.powerOff();
         break;
 
       case pmic_t::pmic_m5pm1:
@@ -2055,7 +2055,7 @@ namespace m5
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
 
     case pmic_t::pmic_py32pmic:
-      return PY32pmic.getPekPress();
+      return M5pm1.getPekPress();
 
     case pmic_t::pmic_m5pm1:
       {

--- a/src/utility/Power_Class.hpp
+++ b/src/utility/Power_Class.hpp
@@ -14,7 +14,7 @@
 #include "power/INA226_Class.hpp"
 #include "power/AW32001_Class.hpp"
 #include "power/BQ27220_Class.hpp"
-#include "power/PY32PMIC_Class.hpp"
+#include "power/M5PM1_Class.hpp"
 #include "RTC_Class.hpp"
 
 #if __has_include (<sdkconfig.h>)
@@ -208,7 +208,7 @@ namespace m5
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
 
     AXP2101_Class Axp2101;
-    PY32PMIC_Class PY32pmic;
+    M5PM1_Class M5pm1;
     INA226_Class Ina226 = { 0x40 };
 
 #elif defined (CONFIG_IDF_TARGET_ESP32C3)

--- a/src/utility/power/M5PM1_Class.cpp
+++ b/src/utility/power/M5PM1_Class.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) M5Stack. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include "PY32PMIC_Class.hpp"
+#include "M5PM1_Class.hpp"
 
 #if __has_include(<esp_log.h>)
 #include <esp_log.h>
@@ -11,22 +11,22 @@
 
 namespace m5
 {
-// PY32PMIC registers
-  static constexpr const uint8_t PY32PMIC_REG_UID_L     = 0x00;
-  static constexpr const uint8_t PY32PMIC_REG_UID_H     = 0x01;
-  static constexpr const uint8_t PY32PMIC_REG_HW_REV    = 0x02;
-  static constexpr const uint8_t PY32PMIC_REG_SW_REV    = 0x03;
+// M5PM1 registers
+  static constexpr const uint8_t M5PM1_REG_UID_L     = 0x00;
+  static constexpr const uint8_t M5PM1_REG_UID_H     = 0x01;
+  static constexpr const uint8_t M5PM1_REG_HW_REV    = 0x02;
+  static constexpr const uint8_t M5PM1_REG_SW_REV    = 0x03;
 
-  static constexpr const uint8_t PY32PMIC_REG_GPIO_MODE = 0x04;
-  static constexpr const uint8_t PY32PMIC_REG_GPIO_OUT  = 0x05;
-  static constexpr const uint8_t PY32PMIC_REG_GPIO_IN   = 0x06;
+  static constexpr const uint8_t M5PM1_REG_GPIO_MODE = 0x04;
+  static constexpr const uint8_t M5PM1_REG_GPIO_OUT  = 0x05;
+  static constexpr const uint8_t M5PM1_REG_GPIO_IN   = 0x06;
 
-  static constexpr const uint8_t PY32PMIC_REG_PWR_CFG   = 0x1C;
+  static constexpr const uint8_t M5PM1_REG_PWR_CFG   = 0x1C;
 
-  static constexpr const uint8_t PY32PMIC_REG_IRQ_Status3 = 0x23;
-  static constexpr const uint8_t PY32PMIC_REG_SYS_CMD   = 0x32;
+  static constexpr const uint8_t M5PM1_REG_IRQ_Status3 = 0x23;
+  static constexpr const uint8_t M5PM1_REG_SYS_CMD   = 0x32;
 
-  bool PY32PMIC_Class::begin(void)
+  bool M5PM1_Class::begin(void)
   {
     if (!_init) {
       std::uint32_t val = 0;
@@ -37,13 +37,13 @@ namespace m5
 
 writeRegister8(0x10, 0x01); // WDT_KEY set
 
-      // res = (val == PY32PMIC_CHIP_ID);
+      // res = (val == M5PM1_CHIP_ID);
         // if (res) {
         //   // disable wdt
-        //   if (readRegister(PY32PMIC_REG_CHR_TMR, &val, 1))
+        //   if (readRegister(M5PM1_REG_CHR_TMR, &val, 1))
         //   {
         //     val = val & 0x1F;
-        //     writeRegister8(PY32PMIC_REG_CHR_TMR, val);
+        //     writeRegister8(M5PM1_REG_CHR_TMR, val);
         //   }
         // }
       }
@@ -63,27 +63,27 @@ writeRegister8(0x10, 0x01); // WDT_KEY set
     return _init;
   }
 
-  bool PY32PMIC_Class::setExtOutput(bool enable)
+  bool M5PM1_Class::setExtOutput(bool enable)
   {
     if (!_init) { return false; }
     if (enable) {
-      return bitOn(PY32PMIC_REG_PWR_CFG, 1 << 3); // set bit 3 to enable external output
+      return bitOn(M5PM1_REG_PWR_CFG, 1 << 3); // set bit 3 to enable external output
     } else {
-      return bitOff(PY32PMIC_REG_PWR_CFG, 1 << 3); // clear bit 3 to disable external output
+      return bitOff(M5PM1_REG_PWR_CFG, 1 << 3); // clear bit 3 to disable external output
     }
   }
 
-  bool PY32PMIC_Class::setBatteryCharge(bool enable)
+  bool M5PM1_Class::setBatteryCharge(bool enable)
   {
     if (!_init) { return false; }
     if (enable) {
-      return bitOn(PY32PMIC_REG_PWR_CFG, 1 << 0); // set bit 0 to enable battery charge
+      return bitOn(M5PM1_REG_PWR_CFG, 1 << 0); // set bit 0 to enable battery charge
     } else {
-      return bitOff(PY32PMIC_REG_PWR_CFG, 1 << 0); // clear bit 0 to disable battery charge
+      return bitOff(M5PM1_REG_PWR_CFG, 1 << 0); // clear bit 0 to disable battery charge
     }
   }
 
-  bool PY32PMIC_Class::setChargeCurrent(std::uint16_t max_mA)
+  bool M5PM1_Class::setChargeCurrent(std::uint16_t max_mA)
   {
     return false;
     // if (!_init) return false;
@@ -91,10 +91,10 @@ writeRegister8(0x10, 0x01); // WDT_KEY set
     // if (value > 0) { value -= 1;  // 0 = 8mA, 63 = 512mA
     //   if (value >= 64) value = 63; // max value is 512mA (8 + 63*8)
     // }
-    // return writeRegister8(PY32PMIC_REG_CHR_CUR, value);
+    // return writeRegister8(M5PM1_REG_CHR_CUR, value);
   }
 
-  bool PY32PMIC_Class::setChargeVoltage(std::uint16_t max_mV)
+  bool M5PM1_Class::setChargeVoltage(std::uint16_t max_mV)
   {
     return false;
     // if (!_init) return false;
@@ -102,48 +102,48 @@ writeRegister8(0x10, 0x01); // WDT_KEY set
     // if (value > 0) { value -= 1;  // 0 = 3600mV, 63 = 4545mV
     //   if (value >= 64) value = 63; // max value is 4545mV (3600 + 63*15)
     // }
-    // uint8_t reg_value = readRegister8(PY32PMIC_REG_CHR_VOL);
+    // uint8_t reg_value = readRegister8(M5PM1_REG_CHR_VOL);
     // reg_value &= 0xC0;
-    // return writeRegister8(PY32PMIC_REG_CHR_VOL, reg_value | value);
+    // return writeRegister8(M5PM1_REG_CHR_VOL, reg_value | value);
   }
 
-  std::uint16_t PY32PMIC_Class::getChargeCurrent(void)
+  std::uint16_t M5PM1_Class::getChargeCurrent(void)
   {
     return 0; // Return 0 if read failed
   }
 
-  std::uint16_t PY32PMIC_Class::getChargeVoltage(void)
+  std::uint16_t M5PM1_Class::getChargeVoltage(void)
   {
     return 0; // Return 0 if read failed
   }
 
-  bool PY32PMIC_Class::isCharging(void)
+  bool M5PM1_Class::isCharging(void)
   {
     return false;
   }
 
-  uint8_t PY32PMIC_Class::getPekPress(void)
+  uint8_t M5PM1_Class::getPekPress(void)
   {
     if (!_init) return 0;
     uint8_t irq3 = 0;
-    if (readRegister(PY32PMIC_REG_IRQ_Status3, &irq3, 1))
+    if (readRegister(M5PM1_REG_IRQ_Status3, &irq3, 1))
     {
       if (irq3) {
         // Clear the IRQ status after reading
         if (irq3 & 0x01) {
-          writeRegister8(PY32PMIC_REG_IRQ_Status3, 0);
+          writeRegister8(M5PM1_REG_IRQ_Status3, 0);
         }
-// printf("PY32PMIC:IRQ3: %02X\n", irq3);
+// printf("M5PM1:IRQ3: %02X\n", irq3);
 // fflush(stdout);
       }
     }
     return (irq3&1) ? 2 : 0;
   }
 
-  bool PY32PMIC_Class::powerOff(void)
+  bool M5PM1_Class::powerOff(void)
   {
     if (_init) {
-      return writeRegister8(PY32PMIC_REG_SYS_CMD, 0xA1); // SYS_CMD / POWER_OFF
+      return writeRegister8(M5PM1_REG_SYS_CMD, 0xA1); // SYS_CMD / POWER_OFF
     }
     return false;
   }

--- a/src/utility/power/M5PM1_Class.hpp
+++ b/src/utility/power/M5PM1_Class.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) M5Stack. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef __M5_M5PM1_CLASS_H__
+#define __M5_M5PM1_CLASS_H__
+
+#include "../I2C_Class.hpp"
+
+namespace m5
+{
+  class M5PM1_Class : public I2C_Device
+  {
+  public:
+    static constexpr std::uint8_t DEFAULT_ADDRESS = 0x6E;
+
+    M5PM1_Class(std::uint8_t i2c_addr = DEFAULT_ADDRESS, std::uint32_t freq = 100000, I2C_Class* i2c = &In_I2C)
+    : I2C_Device ( i2c_addr, freq, i2c )
+    {}
+
+    bool begin(void);
+
+    // true=output / false=input
+    bool setExtOutput(bool enable);
+
+    /// set battery charge enable.
+    /// @param enable true=enable / false=disable
+    bool setBatteryCharge(bool enable);
+
+    /// set battery charge current
+    /// @param max_mA milli ampere. (8 - 512).
+    bool setChargeCurrent(std::uint16_t max_mA);
+
+    /// set battery charge voltage
+    /// @param max_mV milli volt. (3600 - 4545).
+    bool setChargeVoltage(std::uint16_t max_mV);
+
+    /// Get whether the battery is currently charging or not.
+    bool isCharging(void);
+
+    // get setting value of battery charge current
+    /// @return milli ampere. (8 - 512). 0=unknown
+    std::uint16_t getChargeCurrent(void);
+
+    // get setting value of battery charge voltage
+    /// @return milli volt. (3600 - 4545). 0=unknown
+    std::uint16_t getChargeVoltage(void);
+
+    uint8_t getPekPress(void);
+
+    bool powerOff(void);
+  };
+}
+
+#endif

--- a/src/utility/power/PY32PMIC_Class.hpp
+++ b/src/utility/power/PY32PMIC_Class.hpp
@@ -4,51 +4,11 @@
 #ifndef __M5_PY32PMIC_CLASS_H__
 #define __M5_PY32PMIC_CLASS_H__
 
-#include "../I2C_Class.hpp"
+#include "M5PM1_Class.hpp"
 
 namespace m5
 {
-  class PY32PMIC_Class : public I2C_Device
-  {
-  public:
-    static constexpr std::uint8_t DEFAULT_ADDRESS = 0x6E;
-
-    PY32PMIC_Class(std::uint8_t i2c_addr = DEFAULT_ADDRESS, std::uint32_t freq = 100000, I2C_Class* i2c = &In_I2C)
-    : I2C_Device ( i2c_addr, freq, i2c )
-    {}
-
-    bool begin(void);
-
-    // true=output / false=input
-    bool setExtOutput(bool enable);
-
-    /// set battery charge enable.
-    /// @param enable true=enable / false=disable
-    bool setBatteryCharge(bool enable);
-
-    /// set battery charge current
-    /// @param max_mA milli ampere. (8 - 512).
-    bool setChargeCurrent(std::uint16_t max_mA);
-
-    /// set battery charge voltage
-    /// @param max_mV milli volt. (3600 - 4545).
-    bool setChargeVoltage(std::uint16_t max_mV);
-
-    /// Get whether the battery is currently charging or not.
-    bool isCharging(void);
-
-    // get setting value of battery charge current
-    /// @return milli ampere. (8 - 512). 0=unknown
-    std::uint16_t getChargeCurrent(void);
-
-    // get setting value of battery charge voltage
-    /// @return milli volt. (3600 - 4545). 0=unknown
-    std::uint16_t getChargeVoltage(void);
-
-    uint8_t getPekPress(void);
-
-    bool powerOff(void);
-  };
+  using PY32PMIC_Class [[deprecated("Use M5PM1_Class instead")]] = M5PM1_Class;
 }
 
 #endif


### PR DESCRIPTION
## Summary
- Rename the PY32PMIC_Class implementation to M5PM1_Class.
- Keep PY32PMIC_Class as a deprecated compatibility alias.
- Update internal Power_Class references to use M5PM1_Class.