### PR TITLE
Add eFuse-based StampC5 / StampC6 / NanoC6 board detection

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -7,6 +7,7 @@
 #include "utility/PI4IOE5V6408_Class.hpp"
 
 #if !defined (M5UNIFIED_PC_BUILD)
+#include <soc/soc.h>
 #include <soc/efuse_reg.h>
 #include <soc/gpio_periph.h>
 
@@ -1594,8 +1595,20 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
 
 #elif defined (CONFIG_IDF_TARGET_ESP32C6)
     if (board == board_t::board_unknown)
-    { // NanoC6
-      board = board_t::board_M5NanoC6;
+    {
+      if (m5gfx::get_pkg_ver() == 1)
+      { // QFN32 : NanoC6 = C6FH4 (FLASH_CAP=1) / StampC6 = C6FH8 (FLASH_CAP=2)
+        if (REG_GET_FIELD(EFUSE_RD_MAC_SPI_SYS_4_REG, EFUSE_FLASH_CAP) == 2)
+        {
+          board = board_t::board_M5StampC6;
+        }
+        else
+        { // NanoC6
+          board = board_t::board_M5NanoC6;
+        }
+      }
+      // QFN40 (PKG_VERSION=0) : NessoN1 / UnitC6L carry displays and are
+      // identified by M5GFX; an undetected QFN40 board stays unknown.
     }
 
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
@@ -1603,6 +1616,15 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     {
 #if defined (BOARD_ID) && BOARD_ID == 153
       board = board_t::board_M5StampC5;
+#else
+      // StampC5 = ESP32-C5HF4 (in-package 4MB flash, no PSRAM) : FLASH_CAP=1, PSRAM_CAP=0
+      // ToughC5 = ESP32-C5HR8 (8MB PSRAM) carries a display and is identified by M5GFX.
+      std::uint32_t sys2 = REG_READ(EFUSE_RD_MAC_SYS2_REG);
+      if (((sys2 >> EFUSE_FLASH_CAP_S) & EFUSE_FLASH_CAP_V) == 1
+       && ((sys2 >> EFUSE_PSRAM_CAP_S) & EFUSE_PSRAM_CAP_V) == 0)
+      {
+        board = board_t::board_M5StampC5;
+      }
 #endif
     }
 


### PR DESCRIPTION
Adds chip-package eFuse discrimination for display-less C5/C6 boards, so board identity resolves in M5Unified under both Arduino and ESP-IDF.

## Background / policy

By convention, M5GFX identifies boards through display probing and persists the result to NVS — which is only appropriate for boards that actually carry a display. Display-less boards should stay `board_unknown` at the M5GFX layer and be resolved here in M5Unified, where the result is derived fresh each boot (cheap, deterministic, nothing to go stale). This PR provides that resolution for the recent Stamp additions, which also means m5stack/M5GFX#215 does not need M5GFX-side detection (and the StampC5 detection merged in m5stack/M5GFX#214 can later be reduced to a probe-skip gate).

## Changes

**C5**: `BOARD_ID == 153` (Arduino variant) still takes priority; otherwise StampC5 is identified as C5HF4 (`FLASH_CAP==1 && PSRAM_CAP==0` from `EFUSE_RD_MAC_SYS2_REG`). ToughC5 (C5HR8) carries a display and remains M5GFX's job.

**C6**: the previous unconditional `unknown -> NanoC6` fallback is now nested under a package check:

- QFN32 (`PKG_VERSION == 1`): `FLASH_CAP == 2` (C6FH8) → StampC6, otherwise (C6FH4) → NanoC6
- QFN40 (`PKG_VERSION == 0`): NessoN1 / UnitC6L are display boards identified by M5GFX; an undetected QFN40 board now stays `unknown` instead of being mislabeled NanoC6

## Evidence

All discriminator values verified on real hardware (see m5stack/M5GFX#214 / #215 threads):

| board | chip | FLASH_CAP | PSRAM_CAP | PKG_VERSION |
|---|---|---|---|---|
| StampC5 | C5HF4 | 1 | 0 | 0 |
| ToughC5 | C5HR8 | 0 | 2 | 0 |
| NanoC6 | C6FH4 | 1 | — | 1 |

The FH4/FH8 mapping (`1=FH4, 2=FH8`) matches esptool's `esp32c6.py`. A dump on a real StampC6 (expected `FLASH_CAP=2`) would complete the table — @hlym123 could you confirm?

## Verification

- esp32c5 / esp32c6 (IDF v5.5.4): `libM5Unified.a` compiles cleanly
- esp32s3 (Arduino): build regression passes
- Note: StampC6's Ex_I2C pin-table entry is intentionally left out — better filled in by someone with the actual pinout.