### PR TITLE
Switch CI board manager URL to the CN package index

### DIFF
--- a/.github/scripts/fix_m5stack_package_index.py
+++ b/.github/scripts/fix_m5stack_package_index.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Patch stale toolsDependencies in the M5Stack CN package index.
+
+Older platform releases (<= 3.2.1) in package_m5stack_index_cn.json still
+reference tool versions without the "-cn" suffix, while the index itself only
+provides the renamed "-cn" tools, making those platforms uninstallable
+(arduino-cli fails with "tool version ... not found"). Rewrite such
+dependencies to the "-cn" version when that is the one available.
+"""
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+
+patched = 0
+for package in data['packages']:
+    tools = {(t['name'], t['version']) for t in package.get('tools', [])}
+    for platform in package['platforms']:
+        for dep in platform.get('toolsDependencies', []):
+            if dep['packager'] != package['name']:
+                continue
+            if (dep['name'], dep['version']) in tools:
+                continue
+            if (dep['name'], dep['version'] + '-cn') in tools:
+                dep['version'] += '-cn'
+                patched += 1
+
+with open(path, 'w') as f:
+    json.dump(data, f)
+
+print(f'patched {patched} tool dependencies')

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -62,14 +62,14 @@ jobs:
           # M5Core (ESP32)
           - board: m5stack:esp32:m5stack_core
             esp32_version: 2.1.4
-            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json
+            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index_cn.json
           - board: m5stack:esp32:m5stack_core
             esp32_version: 3.2.5
-            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json
+            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index_cn.json
           # M5CoreS3 (ESP32-S3, v3 only)
           - board: m5stack:esp32:m5stack_cores3
             esp32_version: 3.2.5
-            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json
+            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index_cn.json
 
     steps:
       - name: Checkout

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -62,14 +62,14 @@ jobs:
           # M5Core (ESP32)
           - board: m5stack:esp32:m5stack_core
             esp32_version: 2.1.4
-            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index_cn.json
+            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json
           - board: m5stack:esp32:m5stack_core
             esp32_version: 3.2.5
-            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index_cn.json
+            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json
           # M5CoreS3 (ESP32-S3, v3 only)
           - board: m5stack:esp32:m5stack_cores3
             esp32_version: 3.2.5
-            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index_cn.json
+            board_manager_url: https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json
 
     steps:
       - name: Checkout
@@ -99,14 +99,25 @@ jobs:
       - name: Configure arduino-cli
         run: |
           arduino-cli config init
-          # The M5Stack CN index still lists pre-rename tool versions (without
-          # the "-cn" suffix) in the toolsDependencies of older platforms,
-          # which makes them uninstallable. Fetch the index, patch those
-          # entries, and use it as a local index instead.
-          if [[ "${{ matrix.board_manager_url }}" == *package_m5stack_index_cn.json ]]; then
-            curl -fsSL "${{ matrix.board_manager_url }}" -o /tmp/package_m5stack_index.json
-            python3 .github/scripts/fix_m5stack_package_index.py /tmp/package_m5stack_index.json
-            arduino-cli config add board_manager.additional_urls "file:///tmp/package_m5stack_index.json"
+          # The M5Stack index is intermittently unavailable (404 as of
+          # 2026-07). Try the primary URL first and fall back to the CN
+          # mirror. Either index is then passed through a patch script that
+          # fixes stale toolsDependencies entries (the CN index renames all
+          # tools with a "-cn" suffix but older platforms still reference the
+          # pre-rename versions); the script is a no-op on a consistent index.
+          if [[ "${{ matrix.board_manager_url }}" == *package_m5stack_index*.json ]]; then
+            PRIMARY="${{ matrix.board_manager_url }}"
+            INDEX=/tmp/package_m5stack_index.json
+            for url in "$PRIMARY" "${PRIMARY%.json}_cn.json"; do
+              if curl -fsSL "$url" -o "$INDEX"; then
+                echo "Using board manager index: $url"
+                break
+              fi
+              echo "Board manager index unreachable: $url"
+            done
+            [ -s "$INDEX" ] || { echo "No reachable board manager index"; exit 1; }
+            python3 .github/scripts/fix_m5stack_package_index.py "$INDEX"
+            arduino-cli config add board_manager.additional_urls "file://$INDEX"
           else
             arduino-cli config add board_manager.additional_urls ${{ matrix.board_manager_url }}
           fi

--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -99,7 +99,17 @@ jobs:
       - name: Configure arduino-cli
         run: |
           arduino-cli config init
-          arduino-cli config add board_manager.additional_urls ${{ matrix.board_manager_url }}
+          # The M5Stack CN index still lists pre-rename tool versions (without
+          # the "-cn" suffix) in the toolsDependencies of older platforms,
+          # which makes them uninstallable. Fetch the index, patch those
+          # entries, and use it as a local index instead.
+          if [[ "${{ matrix.board_manager_url }}" == *package_m5stack_index_cn.json ]]; then
+            curl -fsSL "${{ matrix.board_manager_url }}" -o /tmp/package_m5stack_index.json
+            python3 .github/scripts/fix_m5stack_package_index.py /tmp/package_m5stack_index.json
+            arduino-cli config add board_manager.additional_urls "file:///tmp/package_m5stack_index.json"
+          else
+            arduino-cli config add board_manager.additional_urls ${{ matrix.board_manager_url }}
+          fi
 
       - name: Install board package
         run: |


### PR DESCRIPTION
## Summary

The M5Stack board manager index used by the Arduino build CI,
`https://static-cdn.m5stack.com/resource/arduino/package_m5stack_index.json`, currently returns **404**, breaking all `m5stack:esp32` matrix entries.

This PR makes the CI resilient to that outage without changing the matrix URLs:

1. **Index URL auto-selection**: the primary index URL is tried first; if unreachable, CI falls back to the `_cn` variant (`package_m5stack_index_cn.json`, currently reachable). When the upstream index recovers, CI automatically returns to the primary with no further changes.
2. **Index patching**: the CN index renames all tools with a `-cn` suffix, but the `toolsDependencies` of older platforms (2.x and <= 3.2.1) still reference the pre-rename versions, so `m5stack:esp32@2.1.4` fails with `tool version esp-2021r2-patch5-8.4.0 not found` (155 such stale entries overall). A small script rewrites those dependencies to their `-cn` equivalents; it is a no-op on a consistent index. The fetched index is used locally via `file://`.

## Verification

- Primary URL: HTTP 404 (confirmed 2026-07-07); no alternative mirror of the non-CN index found.
- CN URL: HTTP 200, contains both platform versions used by the CI matrix (`2.1.4`, `3.2.5`); all download hosts it references verified reachable.
- Fallback loop verified locally: primary 404 -> falls back to CN -> patch fixes 155 stale entries.
- With the patched index, `arduino-cli core install m5stack:esp32@2.1.4` resolves dependencies and starts the toolchain download (verified locally); the unpatched CN index fails dependency resolution.
- First CI run on this PR confirmed the diagnosis: `3.2.5` passed with the CN index, `2.1.4` failed exactly on the stale dependency.

Same fix as m5stack/M5GFX#219.