### PR TITLE
Update supported board information and require M5GFX >=0.2.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,24 +65,35 @@ or have explicit support in the M5Unified library.  To use these functions, simp
  - M5StickS3
  - M5ATOMS3 / S3Lite / S3U
  - M5ATOMS3R / S3RExt / S3RCam / ECHO S3R
- - M5STAMPS3 (S3 / S3A)
+ - M5STAMPS3 (S3 / S3A) / S3Bat / S3Mini
+ - M5STAMPPLC
  - M5Dial
  - M5DinMeter
  - M5Capsule
  - M5Cardputer / M5CardputerADV
  - M5VAMeter
+ - M5AirQ
  - M5PaperS3
  - M5PaperColor
  - M5PaperMono
+ - M5PaperDIY
  - M5PowerHub
  - M5StopWatch
+ - M5StackChan
+ - M5ChainCaptain
+ - M5DualKey
 
 ## Supported devices (ESP32-C3)
  - M5STAMPC3 / C3U
 
+## Supported devices (ESP32-C5)
+ - M5STAMPC5
+ - M5ToughC5
+
 ## Supported devices (ESP32-C6)
  - M5NanoC6
  - M5UnitC6L
+ - M5STAMPC6
  - ArduinoNessoN1
 
 ## Supported devices (ESP32-H2)
@@ -90,6 +101,8 @@ or have explicit support in the M5Unified library.  To use these functions, simp
 
 ## Supported devices (ESP32-P4)
  - M5Tab5
+ - M5STAMPP4
+ - M5UnitPoEP4
 
 ## Supported external displays and video adapters
  - Unit LCD

--- a/examples/Basic/HowToUse/HowToUse.ino
+++ b/examples/Basic/HowToUse/HowToUse.ino
@@ -285,6 +285,9 @@ void setup(void)
   case m5::board_t::board_M5StackCoreS3SE:  name = "StackCoreS3SE";  break;
   case m5::board_t::board_M5StickS3:        name = "StickS3";        break;
   case m5::board_t::board_M5StampS3:        name = "StampS3";        break;
+  case m5::board_t::board_M5StampS3Bat:     name = "StampS3Bat";     break;
+  case m5::board_t::board_M5StampS3Mini:    name = "StampS3Mini";    break;
+  case m5::board_t::board_M5StampPLC:       name = "StampPLC";       break;
   case m5::board_t::board_M5AtomS3U:        name = "ATOMS3U";        break;
   case m5::board_t::board_M5AtomS3Lite:     name = "ATOMS3Lite";     break;
   case m5::board_t::board_M5AtomS3:         name = "ATOMS3";         break;
@@ -299,22 +302,32 @@ void setup(void)
   case m5::board_t::board_M5CardputerADV:   name = "CardputerADV";   break;
   case m5::board_t::board_M5VAMeter:        name = "VAMeter";        break;
   case m5::board_t::board_M5PaperS3:        name = "PaperS3";        break;
+  case m5::board_t::board_M5PaperDIY:       name = "PaperDIY";       break;
   case m5::board_t::board_M5PowerHub:       name = "PowerHub";       break;
   case m5::board_t::board_M5PaperColor:     name = "PaperColor";     break;
   case m5::board_t::board_M5PaperMono:      name = "PaperMono";      break;
   case m5::board_t::board_M5StopWatch:      name = "StopWatch";      break;
+  case m5::board_t::board_M5AirQ:           name = "AirQ";           break;
+  case m5::board_t::board_M5StackChan:      name = "StackChan";      break;
+  case m5::board_t::board_M5ChainCaptain:   name = "ChainCaptain";   break;
+  case m5::board_t::board_M5DualKey:        name = "DualKey";        break;
 #elif defined (CONFIG_IDF_TARGET_ESP32C3)
   case m5::board_t::board_M5StampC3:        name = "StampC3";        break;
   case m5::board_t::board_M5StampC3U:       name = "StampC3U";       break;
+#elif defined (CONFIG_IDF_TARGET_ESP32C5)
+  case m5::board_t::board_M5StampC5:        name = "StampC5";        break;
+  case m5::board_t::board_M5ToughC5:        name = "ToughC5";        break;
 #elif defined (CONFIG_IDF_TARGET_ESP32C6)
   case m5::board_t::board_M5NanoC6:         name = "NanoC6";         break;
   case m5::board_t::board_M5UnitC6L:        name = "UnitC6L";        break;
+  case m5::board_t::board_M5StampC6:        name = "StampC6";        break;
   case m5::board_t::board_ArduinoNessoN1:   name = "NessoN1";        break;
 #elif defined (CONFIG_IDF_TARGET_ESP32H2)
-  case m5::board_t::board_NanoH2:           name = "NanoH2";         break;
+  case m5::board_t::board_M5NanoH2:         name = "NanoH2";         break;
 #elif defined (CONFIG_IDF_TARGET_ESP32P4)
   case m5::board_t::board_M5Tab5:           name = "Tab5";           break;
-  case m5::board_t::board_M5UnitPoEP4:      name = "UnitPoEP4";      break; 
+  case m5::board_t::board_M5UnitPoEP4:      name = "UnitPoEP4";      break;
+  case m5::board_t::board_M5StampP4:        name = "StampP4";        break;
 #else
   case m5::board_t::board_M5Stack:          name = "Stack";          break;
   case m5::board_t::board_M5StackCore2:     name = "StackCore2";     break;

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -5,4 +5,4 @@ url: https://github.com/m5stack/M5Unified.git
 version: 0.2.19
 dependencies:
   m5stack/m5gfx:
-    version: ">=0.2.25"
+    version: ">=0.2.26"

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "M5GFX",
-      "version": ">=0.2.25"
+      "version": ">=0.2.26"
     }
   ],
   "version": "0.2.19",


### PR DESCRIPTION
### Changes

- Require M5GFX >=0.2.26 (library.json / idf_component.yml). The M5PaperDIY support merged in #281 references `board_M5PaperDIY`, which was added in M5GFX 0.2.26.
- Add recently added boards to the HowToUse example and README supported device lists:
  - ESP32-S3: PaperDIY / StampS3Bat / StampS3Mini / StampPLC / AirQ / StackChan / ChainCaptain / DualKey
  - ESP32-C5: new section (StampC5 / ToughC5)
  - ESP32-C6: StampC6
  - ESP32-P4: StampP4
- Fix a nonexistent enum name in the ESP32-H2 section of HowToUse: `board_NanoH2` -> `board_M5NanoH2`