### PR TITLE
Fix external RTC detection on Port A and the sleep wakeup handling

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1264,6 +1264,12 @@ namespace m5
 
   void Power_Class::deepSleep(std::uint64_t micro_seconds, bool touch_wakeup)
   {
+    if (micro_seconds == 0)
+    { // A wakeup time of zero means "do not sleep".
+      // ( This check comes before the display is put to sleep. )
+      M5_LOGW("deepSleep: micro_seconds is 0. not sleeping. ( use Power.sleep_no_timer to sleep without a timer wakeup )");
+      return;
+    }
     M5.Display.sleep();
     M5.Display.waitDisplay();
 #if defined (M5UNIFIED_PC_BUILD)
@@ -1318,10 +1324,10 @@ namespace m5
       else
       { // The wakeup pin is not an RTC IO. ( ex. M5PaperS3 touch INT = GPIO48 )
         // Such a pin can wake up from light sleep, but not from deep sleep.
-        ESP_LOGW("Power", "deepSleep: GPIO%d cannot be used as a deep sleep wakeup source.", (int)wpin);
+        M5_LOGW("deepSleep: GPIO%d cannot be used as a deep sleep wakeup source.", (int)wpin);
       }
     }
-    if (micro_seconds > 0)
+    if (micro_seconds != sleep_no_timer)
     {
       esp_sleep_enable_timer_wakeup(micro_seconds);
     }
@@ -1331,7 +1337,7 @@ namespace m5
       if (!pin_wakeup_enabled)
       { // Neither a timer nor a wakeup pin was configured by this call.
         // Unless another wakeup source has been set up, the device will not wake up until it is reset.
-        ESP_LOGW("Power", "deepSleep: no timer or pin wakeup source was requested.");
+        M5_LOGW("deepSleep: no timer or pin wakeup source is enabled.");
       }
     }
 #endif
@@ -1341,6 +1347,11 @@ namespace m5
 
   void Power_Class::lightSleep(std::uint64_t micro_seconds, bool touch_wakeup)
   {
+    if (micro_seconds == 0)
+    { // A wakeup time of zero means "do not sleep".
+      M5_LOGW("lightSleep: micro_seconds is 0. not sleeping. ( use Power.sleep_no_timer to sleep without a timer wakeup )");
+      return;
+    }
 #if defined (M5UNIFIED_PC_BUILD)
     (void)micro_seconds;
     (void)touch_wakeup;
@@ -1362,31 +1373,43 @@ namespace m5
     {
       wpin = GPIO_NUM_4;
     }
+    bool pin_wakeup_enabled = false;
     if (touch_wakeup && wpin < GPIO_NUM_MAX)
     {
       if (M5.getBoard() == board_t::board_M5PaperS3)
       {
         // M5PaperS3 touch interrupt pin (GPIO48) is not RTC IO
         // and therefore not supported in EXT0 wakeup
-        gpio_wakeup_enable((gpio_num_t)wpin, gpio_int_type_t::GPIO_INTR_LOW_LEVEL);
-        esp_sleep_enable_gpio_wakeup();
+        pin_wakeup_enabled = (ESP_OK == gpio_wakeup_enable((gpio_num_t)wpin, gpio_int_type_t::GPIO_INTR_LOW_LEVEL))
+                          && (ESP_OK == esp_sleep_enable_gpio_wakeup());
       }
       else
       {
 #if SOC_PM_SUPPORT_EXT0_WAKEUP
-        esp_sleep_enable_ext0_wakeup((gpio_num_t)wpin, false);
+        pin_wakeup_enabled = (ESP_OK == esp_sleep_enable_ext0_wakeup((gpio_num_t)wpin, false));
         esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_AUTO);
 #endif
       }
-      while (m5gfx::gpio_in(wpin) == false)
+      if (pin_wakeup_enabled)
       {
-        m5gfx::delay(10);
+        while (m5gfx::gpio_in(wpin) == false)
+        {
+          m5gfx::delay(10);
+        }
+      }
+      else
+      {
+        M5_LOGW("lightSleep: wakeup by GPIO%d is not enabled.", (int)wpin);
       }
     }
-    if (micro_seconds > 0){
+    if (micro_seconds != sleep_no_timer){
       esp_sleep_enable_timer_wakeup(micro_seconds);
     }else{
       esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+      if (!pin_wakeup_enabled)
+      { // Neither a timer nor a wakeup pin was configured by this call.
+        M5_LOGW("lightSleep: no timer or pin wakeup source is enabled.");
+      }
     }
     esp_light_sleep_start();
     if (M5.getBoard() == board_t::board_M5PaperS3)

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1287,23 +1287,38 @@ namespace m5
     {
       wpin = GPIO_NUM_4;
     }
+    bool pin_wakeup_enabled = false;
     if (touch_wakeup && wpin < GPIO_NUM_MAX)
     {
 #if SOC_PM_SUPPORT_EXT0_WAKEUP
-      esp_sleep_enable_ext0_wakeup((gpio_num_t)wpin, false);
+      pin_wakeup_enabled = (ESP_OK == esp_sleep_enable_ext0_wakeup((gpio_num_t)wpin, false));
 #elif SOC_PM_SUPPORT_EXT1_WAKEUP && SOC_RTCIO_PIN_COUNT > 0
-      const uint64_t ext_wakeup_pin_1_mask = 1ULL << _wakeupPin;
-      ESP_ERROR_CHECK(esp_sleep_enable_ext1_wakeup_io(ext_wakeup_pin_1_mask, ESP_EXT1_WAKEUP_ANY_LOW));
- #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
-      ESP_ERROR_CHECK(rtc_gpio_pullup_dis((gpio_num_t)_wakeupPin));
-      ESP_ERROR_CHECK(rtc_gpio_pulldown_en((gpio_num_t)_wakeupPin));
- #endif
-#endif
-      while (m5gfx::gpio_in(wpin) == false)
+      if (rtc_gpio_is_valid_gpio((gpio_num_t)wpin))
       {
-        // Issue #91, ( M5Paper wakes too soon from deep sleep when touch wakeup is enabled - with solution )
-        M5.update();
-        m5gfx::delay(10);
+        const uint64_t ext_wakeup_pin_1_mask = 1ULL << wpin;
+        pin_wakeup_enabled = (ESP_OK == esp_sleep_enable_ext1_wakeup_io(ext_wakeup_pin_1_mask, ESP_EXT1_WAKEUP_ANY_LOW));
+ #if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+        if (pin_wakeup_enabled)
+        {
+          rtc_gpio_pullup_dis((gpio_num_t)wpin);
+          rtc_gpio_pulldown_en((gpio_num_t)wpin);
+        }
+ #endif
+      }
+#endif
+      if (pin_wakeup_enabled)
+      {
+        while (m5gfx::gpio_in(wpin) == false)
+        {
+          // Issue #91, ( M5Paper wakes too soon from deep sleep when touch wakeup is enabled - with solution )
+          M5.update();
+          m5gfx::delay(10);
+        }
+      }
+      else
+      { // The wakeup pin is not an RTC IO. ( ex. M5PaperS3 touch INT = GPIO48 )
+        // Such a pin can wake up from light sleep, but not from deep sleep.
+        ESP_LOGW("Power", "deepSleep: GPIO%d cannot be used as a deep sleep wakeup source.", (int)wpin);
       }
     }
     if (micro_seconds > 0)
@@ -1313,6 +1328,11 @@ namespace m5
     else
     {
       esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+      if (!pin_wakeup_enabled)
+      { // Neither a timer nor a wakeup pin was configured by this call.
+        // Unless another wakeup source has been set up, the device will not wake up until it is reset.
+        ESP_LOGW("Power", "deepSleep: no timer or pin wakeup source was requested.");
+      }
     }
 #endif
     esp_deep_sleep_start();

--- a/src/utility/Power_Class.hpp
+++ b/src/utility/Power_Class.hpp
@@ -136,13 +136,20 @@ namespace m5
     /// @attention CoreInk と M5Paper は USB接続中はRTCタイマー起動が出来ない。;
     void timerSleep(const rtc_date_t& date, const rtc_time_t& time);
 
+    /// Value for micro_seconds of deepSleep / lightSleep, meaning "sleep without a timer wakeup".
+    /// The device sleeps until a wakeup pin or another wakeup source is triggered.
+    static constexpr std::uint64_t sleep_no_timer = ~0ull;
+
     /// ESP32 deepsleep
-    /// @param micro_seconds Number of micro seconds to wakeup.
-    void deepSleep(std::uint64_t micro_seconds = 0, bool touch_wakeup = true);
+    /// @param micro_seconds Number of micro seconds to wakeup. 0 = do not sleep. sleep_no_timer = no timer wakeup.
+    /// @param touch_wakeup Enable wakeup by the wakeup pin of the device, if it has one.
+    /// @attention Waking up from deep sleep restarts the program from the beginning.
+    void deepSleep(std::uint64_t micro_seconds = sleep_no_timer, bool touch_wakeup = true);
 
     /// ESP32 lightsleep
-    /// @param micro_seconds Number of micro seconds to wakeup.
-    void lightSleep(std::uint64_t micro_seconds = 0, bool touch_wakeup = true);
+    /// @param micro_seconds Number of micro seconds to wakeup. 0 = do not sleep. sleep_no_timer = no timer wakeup.
+    /// @param touch_wakeup Enable wakeup by the wakeup pin of the device, if it has one.
+    void lightSleep(std::uint64_t micro_seconds = sleep_no_timer, bool touch_wakeup = true);
 
     /// Get the remaining battery power.
     /// @return 0-100 level

--- a/src/utility/RTC_Class.cpp
+++ b/src/utility/RTC_Class.cpp
@@ -69,7 +69,7 @@ namespace m5
 
     if (instance == nullptr)
     {
-      instance.reset(new PCF8563_Class(PCF8563_Class::DEFAULT_ADDRESS, 400000));
+      instance.reset(new PCF8563_Class(PCF8563_Class::DEFAULT_ADDRESS, 400000, i2c));
     }
 
     if (instance->begin())


### PR DESCRIPTION
Three independent fixes found while going through the open issues. Each one is a separate commit.

### 1. External RTC on Port A is never detected (#266)

`RTC_Class::begin()` passes the given `I2C_Class*` to the RX8130 instances, but not to the PCF8563 fallback, whose third parameter defaults to `&In_I2C`. With `cfg.external_rtc = true` the call `M5.Rtc.begin(&M5.Ex_I2C)` therefore probes the *internal* bus, and UNIT-RTC on Port A is never found.

The argument was present in v0.2.10 and was dropped in e35a905 (first released in v0.2.11), which matches the reporter's version bisection - including why M5Grey is the one board that still works: its internal bus is G21/G22, the same pins as Port A.

### 2. deepSleep() aborts on M5PaperS3 when touch_wakeup is requested (#205)

On targets without EXT0 support, `deepSleep()` enabled EXT1 wakeup unconditionally inside `ESP_ERROR_CHECK`. The PaperS3 touch INT pin is GPIO48, which is not an RTC IO, so `esp_sleep_enable_ext1_wakeup_io()` returns `ESP_ERR_INVALID_ARG` and the call aborts instead of sleeping. `lightSleep()` already handled this case with `gpio_wakeup_enable()`.

The pin is now validated with `rtc_gpio_is_valid_gpio()`, and a warning is logged when it cannot be used as a deep sleep wakeup source.

The same block also built the EXT1 pin mask from `_wakeupPin` while the wait loop used `wpin`, so the M5PaperMono override (GPIO4) never reached the mask; both use `wpin` now.

### 3. A sleep duration of zero silently means "sleep forever" (#285)

`micro_seconds = 0` meant "no timer wakeup", and 0 was also the default argument - so `deepSleep()` with no arguments means "sleep until the wakeup pin triggers". A caller that computes a duration and accidentally ends up with 0 sleeps until an external reset, which is hard to tell apart from a freeze.

That intent now has its own value:

```cpp
    static constexpr std::uint64_t sleep_no_timer = ~0ull;

    void deepSleep (std::uint64_t micro_seconds = sleep_no_timer, bool touch_wakeup = true);
    void lightSleep(std::uint64_t micro_seconds = sleep_no_timer, bool touch_wakeup = true);
```

- calls without arguments behave exactly as before;
- an explicit `0` no longer sleeps and logs a warning instead. For `deepSleep()` the check runs *before* `M5.Display.sleep()`, so the caller resumes with the display still on;
- the sentinel is never handed to `esp_sleep_enable_timer_wakeup()` (about 580,000 years, which would be rejected) - it keeps taking the "disable the timer wakeup source" path;
- `lightSleep()` now also tracks whether a wakeup pin was actually enabled, and warns when neither a timer nor a pin wakeup source is in effect.

**This is a breaking change** for code that passes a literal `0` in order to sleep indefinitely: such code needs `M5.Power.sleep_no_timer` instead. In public GitHub code the no-argument form outnumbers explicit `0` by roughly 97 to 11, and the direction of the change is the safe one - the device stays awake and logs why, rather than never waking up.

### Verification

Builds cleanly with PlatformIO for `esp32` (EXT0 path), `esp32s3` (EXT1 path) and the PC build (`M5UNIFIED_PC_BUILD`).

Not verified on hardware yet - `deepSleep()` on PaperS3 and UNIT-RTC on Port A would be the two worth checking.


