### PR TITLE
Implement getAPSVoltage and return NaN from the unavailable AXP2101 getters

### DIFF
--- a/src/utility/Power_Class.hpp
+++ b/src/utility/Power_Class.hpp
@@ -184,6 +184,9 @@ namespace m5
 
     /// get battery current
     /// @return battery current [mA] ( +=charge / -=discharge )
+    /// @attention This reading comes from the hardware of the board: an AXP192, or a
+    /// dedicated current sense IC ( ex. Core2 v1.1 , M5Tab5 , M5PowerHub ).
+    /// Boards without either of them return 0.
     int32_t getBatteryCurrent(void);
 
     /// Get Ext Port voltage

--- a/src/utility/power/AXP2101_Class.cpp
+++ b/src/utility/power/AXP2101_Class.cpp
@@ -272,7 +272,7 @@ return false;
   float AXP2101_Class::getBatteryChargeCurrent(void)
   { // The ADC of the AXP2101 covers VBAT / TS / VBUS / VSYS / TDIE. Current is measured
     // by a dedicated sense IC where the board provides one ( ex. INA3221 on Core2 v1.1 ,
-    // INA226 on Tab5 ) , and Power_Class::getBatteryCurrent() reads that IC.
+    // INA226 on M5Tab5 ) , and Power_Class::getBatteryCurrent() reads that IC.
     return not_available();
   }
 

--- a/src/utility/power/AXP2101_Class.cpp
+++ b/src/utility/power/AXP2101_Class.cpp
@@ -221,6 +221,10 @@ return false;
     return std::numeric_limits<float>::quiet_NaN();
   }
 
+  /// A 14 bit ADC channel reads close to its full scale ( 0x3FFF ) when there is
+  /// nothing to measure on it. Values from here up are not treated as a reading.
+  static constexpr std::size_t adc_invalid_min = 16375;
+
   float AXP2101_Class::getACINVoltage(void)
   { // The AXP2101 takes its input from VBUS. ( see getVBUSVoltage )
     return not_available();
@@ -236,7 +240,7 @@ return false;
     if (isVBUS() == false) { return 0.0f; }
     
     float vBus = readRegister14(0x38);
-    if (vBus >= 16375) { return 0.0f; }
+    if (vBus >= adc_invalid_min) { return 0.0f; }
 
     return vBus / 1000.0f;
   }
@@ -249,7 +253,7 @@ return false;
   float AXP2101_Class::getTSVoltage(void)
   {
     float volt = readRegister14(0x36);
-    if (volt >= 16375) { return 0.0f; }
+    if (volt >= adc_invalid_min) { return 0.0f; }
 
     return volt / 2000.0f;
   }
@@ -285,7 +289,7 @@ return false;
   { // VSYS is the equivalent measurement point on the AXP2101 of the APS rail
     // of the AXP192.
     float volt = readRegister14(0x3A);
-    if (volt >= 16375) { return 0.0f; }
+    if (volt >= adc_invalid_min) { return 0.0f; }
 
     return volt / 1000.0f;
   }

--- a/src/utility/power/AXP2101_Class.cpp
+++ b/src/utility/power/AXP2101_Class.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include <algorithm>
+#include <limits>
 
 #define IS_BIT_SET(val,mask)            (((val)&(mask)) == (mask))
 
@@ -213,14 +214,21 @@ return false;
     return val >> 2;
   }
 
-  float AXP2101_Class::getACINVoltage(void)
+  /// Used where the AXP2101 provides no reading for the requested value.
+  /// Returning NaN instead of 0 lets the caller tell it from a real zero.
+  static constexpr float not_available(void)
   {
-return 0;
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+
+  float AXP2101_Class::getACINVoltage(void)
+  { // The AXP2101 takes its input from VBUS. ( see getVBUSVoltage )
+    return not_available();
   }
 
   float AXP2101_Class::getACINCurrent(void)
-  {
-return 0;
+  { // The AXP2101 takes its input from VBUS.
+    return not_available();
   }
 
   float AXP2101_Class::getVBUSVoltage(void)
@@ -234,8 +242,8 @@ return 0;
   }
 
   float AXP2101_Class::getVBUSCurrent(void)
-  {
-return 0;
+  { // Not provided by the AXP2101. ( see getBatteryChargeCurrent )
+    return not_available();
   }
 
   float AXP2101_Class::getTSVoltage(void)
@@ -252,8 +260,8 @@ return 0;
   }
 
   float AXP2101_Class::getBatteryPower(void)
-  {
-return 0;
+  { // Derived from the battery current, which the AXP2101 does not provide.
+    return not_available();
   }
 
   float AXP2101_Class::getBatteryVoltage(void)
@@ -262,18 +270,24 @@ return 0;
   }
 
   float AXP2101_Class::getBatteryChargeCurrent(void)
-  {
-return 0;
+  { // The ADC of the AXP2101 covers VBAT / TS / VBUS / VSYS / TDIE. Current is measured
+    // by a dedicated sense IC where the board provides one ( ex. INA3221 on Core2 v1.1 ,
+    // INA226 on Tab5 ) , and Power_Class::getBatteryCurrent() reads that IC.
+    return not_available();
   }
 
   float AXP2101_Class::getBatteryDischargeCurrent(void)
-  {
-return 0;
+  { // Not provided by the AXP2101. ( see getBatteryChargeCurrent )
+    return not_available();
   }
 
   float AXP2101_Class::getAPSVoltage(void)
-  {
-return 0;
+  { // VSYS is the equivalent measurement point on the AXP2101 of the APS rail
+    // of the AXP192.
+    float volt = readRegister14(0x3A);
+    if (volt >= 16375) { return 0.0f; }
+
+    return volt / 1000.0f;
   }
 
   bool AXP2101_Class::enableIRQ(std::uint64_t registerEn)

--- a/src/utility/power/AXP2101_Class.cpp
+++ b/src/utility/power/AXP2101_Class.cpp
@@ -221,9 +221,12 @@ return false;
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  /// A 14 bit ADC channel reads close to its full scale ( 0x3FFF ) when there is
-  /// nothing to measure on it. Values from here up are not treated as a reading.
-  static constexpr std::size_t adc_invalid_min = 16375;
+  /// A 14 bit ADC channel sits at the top of its range when there is nothing to measure
+  /// on it, so a reading within this margin of full scale is not treated as a value.
+  /// A channel that does have an input reads far below the margin; measured on a CoreS3,
+  /// the closest was TS at 5563, while VBUS with nothing connected read 16372.
+  static constexpr std::size_t adc_full_scale  = 0x3FFF;
+  static constexpr std::size_t adc_invalid_min = adc_full_scale - 32;
 
   float AXP2101_Class::getACINVoltage(void)
   { // The AXP2101 takes its input from VBUS. ( see getVBUSVoltage )

--- a/src/utility/power/AXP2101_Class.hpp
+++ b/src/utility/power/AXP2101_Class.hpp
@@ -122,15 +122,30 @@ namespace m5
     bool isVBUS(void);
     bool getBatState(void);
 
+    /// The ADC of the AXP2101 covers these measurement points:
+    ///   VBAT , TS , VBUS , VSYS , TDIE
+    /// The getters below that fall outside this set return NaN, so that a caller can
+    /// tell an unavailable reading from a real zero with std::isnan().
+    /// Current is measured by a dedicated sense IC where the board provides one
+    /// ( ex. INA3221 on Core2 v1.1 , INA226 on M5Tab5 ) , and Power_Class reads that IC.
+
     float getBatteryVoltage(void);
+    /// @return NaN. This reading is not provided by the AXP2101.
     float getBatteryDischargeCurrent(void);
+    /// @return NaN. This reading is not provided by the AXP2101.
     float getBatteryChargeCurrent(void);
+    /// @return NaN. Derived from the battery current, which the AXP2101 does not provide.
     float getBatteryPower(void);
+    /// @return NaN. The AXP2101 takes its input from VBUS. ( see getVBUSVoltage )
     float getACINVoltage(void);
+    /// @return NaN. The AXP2101 takes its input from VBUS.
     float getACINCurrent(void);
     float getVBUSVoltage(void);
+    /// @return NaN. This reading is not provided by the AXP2101.
     float getVBUSCurrent(void);
     float getTSVoltage(void);
+    /// The VSYS voltage is returned, which is the equivalent measurement point on the
+    /// AXP2101 of the APS rail of the AXP192.
     float getAPSVoltage(void);
     float getInternalTemperature(void);
 


### PR DESCRIPTION
Relates to #86 and #215.

Seven getters of `AXP2101_Class` returned `0` without reading anything:

```cpp
  float AXP2101_Class::getBatteryChargeCurrent(void)
  {
return 0;
  }
```

A returned `0` is indistinguishable from a valid measurement of zero, which is what led to both reports.

## What the ADC provides

The ADC of the AXP2101 covers these measurement points:

| channel | register |
|---|---|
| VBAT | `0x34` |
| TS | `0x36` |
| VBUS | `0x38` |
| **VSYS** | `0x3A` |
| TDIE | `0x3C` |

Of the seven getters, one falls inside this set and six do not.

## Changes

**`getAPSVoltage()` is implemented.** VSYS is the equivalent measurement point on the AXP2101 of the APS rail of the AXP192, and it was the one channel not yet used. Measured 3.776 V on a CoreS3 while the AXP2101 was supplying the system, and 4.246 V with the charger connected.

**The other six return NaN**, so a caller can tell an unavailable reading from a real zero with `std::isnan()`. Nothing inside the library calls them, so no other behaviour changes.

**Documentation** is added for what each getter provides. `Power_Class::getBatteryCurrent()` also gains a note that the value comes from an AXP192 or from a dedicated current sense IC — the INA3221 on Core2 v1.1, the INA226 on M5Tab5 — and that boards carrying neither return 0.

## How the set of channels was checked

Rather than relying on the register map alone, the whole 256 byte register space was dumped on a CoreS3 with a battery attached, once while charging and once while running from the battery, and the two dumps were compared. Registers that also moved between two consecutive dumps in the same state were excluded as normal fluctuation.

Ten registers differed:

| register | charging | on battery | meaning |
|---|---|---|---|
| `0x00` | 38 | 18 | VBUS good bit |
| `0x01` | 32 | 55 | charge state bits |
| `0x35` | C4 | 5C | VBAT low byte, 4036 mV → 3932 mV |
| `0x38` `0x39` | 13 A0 | 3F F4 | VBUS, 5024 mV → invalid marker |
| `0x3A` `0x3B` | 10 96 | 0F 5A | VSYS, 4246 mV → 3930 mV |
| `0x49` | A3 | 63 | IRQ / PEK status |
| `0xA4` | 0D | 0E | battery percentage, 13 % → 14 % |
| `0xA9` | 20 | 21 | fuel gauge status |

Everything that responds to the charge state is a voltage, a status bit or the fuel gauge percentage, which matches the channel list above.

## Verification

Measured on a CoreS3 with a battery attached, Arduino 2.0.17 (ESP-IDF 4.4):

```
APS=4.218  VBAT=4.008  VBUS=5.029
chgI=nan  dscI=nan  pow=nan  acinV=nan  acinI=nan  vbusI=nan
```

Build checked for ESP32-S3 (ESP-IDF 4.4 / 5.5), ESP32 and the PC build.


## Follow-up from the review

The literal `16375`, which marks an ADC channel as having nothing to read, is now named. It appeared at every such check and `getAPSVoltage()` added a third one, so all three sites were changed together rather than only the one that was pointed out.

While naming it, the value turned out to be narrower than where a channel actually settles. It was full scale minus 8, but VBUS with nothing connected reads 16372 on a CoreS3, which is full scale minus 11 and slips through. The way the threshold is defined is kept and the margin is widened to 32:

```cpp
  static constexpr std::size_t adc_full_scale  = 0x3FFF;
  static constexpr std::size_t adc_invalid_min = adc_full_scale - 32;
```

That is three times the distance measured above, and a channel that does have an input stays far away from it — the closest on the same board was TS at 5563, and every other channel read below 5100.

Measured on a CoreS3 with a battery attached:

| channel | raw | distance from full scale |
|---|---|---|
| VBAT | 4205 | 12178 |
| TS | 5563 | 10820 |
| VBUS | 5038 | 11345 |
| VSYS | 4414 | 11969 |
| VBUS, nothing connected | 16372 | 11 |

This does not change what any getter returns today: `getVBUSVoltage()` is already guarded by `isVBUS()`, and TS and VSYS always have an input on the boards in question, so no path reached the threshold with a railed value.
