### PR TITLE
Report a recording as pending from the moment it is requested

### DIFF
--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -733,13 +733,16 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 #if portNUM_PROCESSORS > 1
       if (_cfg.task_pinned_core < portNUM_PROCESSORS)
       {
-        xTaskCreatePinnedToCore(mic_task, "mic_task", stack_size, this, _cfg.task_priority, &_task_handle, _cfg.task_pinned_core);
+        res = (pdPASS == xTaskCreatePinnedToCore(mic_task, "mic_task", stack_size, this, _cfg.task_priority, &_task_handle, _cfg.task_pinned_core));
       }
       else
 #endif
       {
-        xTaskCreate(mic_task, "mic_task", stack_size, this, _cfg.task_priority, &_task_handle);
+        res = (pdPASS == xTaskCreate(mic_task, "mic_task", stack_size, this, _cfg.task_priority, &_task_handle));
       }
+      // end() takes the driver and the callback back down; it still sees the
+      // class as running, which is what lets it do that.
+      if (!res) { end(); }
     }
 
     return res;

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -584,7 +584,6 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
         dst_remain = current_rec->length;
         if (dst_remain == 0)
         {
-          self->_is_recording = false;
           ulTaskNotifyTake( pdTRUE, portMAX_DELAY );
           src_idx = ~0u;
           src_len = 0;
@@ -593,7 +592,6 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
           continue;
         }
       }
-      self->_is_recording = true;
 
       for (;;)
       {
@@ -702,7 +700,6 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
         }
       }
     }
-    self->_is_recording = false;
     _i2s_stop(self->_cfg.i2s_port);
 
     self->_task_handle = nullptr;
@@ -757,6 +754,10 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
       if (_task_handle) { xTaskNotifyGive(_task_handle); }
       do { vTaskDelay(1); } while (_task_handle);
     }
+
+    // an unfinished request would otherwise keep isRecording() reporting a recording.
+    _rec_info[0] = recording_info_t();
+    _rec_info[1] = recording_info_t();
 
     if (_cb_set_enabled) { _cb_set_enabled(_cb_set_enabled_args, false); }
     _i2s_driver_uninstall(_cfg.i2s_port);

--- a/src/utility/Mic_Class.hpp
+++ b/src/utility/Mic_Class.hpp
@@ -114,7 +114,7 @@ namespace m5
 
     /// now in recording or not.
     /// @return 0=not recording / 1=recording (There's room in the queue) / 2=recording (There's no room in the queue.)
-    size_t isRecording(void) const { return _is_recording ? ((bool)_rec_info[0].length) + ((bool)_rec_info[1].length) : 0; }
+    size_t isRecording(void) const volatile { return ((bool)_rec_info[0].length) + ((bool)_rec_info[1].length); }
 
     /// set recording sampling rate.
     /// @param sample_rate the sampling rate (Hz)
@@ -186,7 +186,6 @@ namespace m5
 
     int32_t _offset = 0;
     volatile bool _task_running = false;
-    volatile bool _is_recording = false;
 #if defined (SDL_h_)
     SDL_Thread* _task_handle = nullptr;
 #else

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -930,20 +930,24 @@ label_continue_sample:
       _task_running = true;
 #if defined (SDL_h_)
       _task_handle = SDL_CreateThread(reinterpret_cast<SDL_ThreadFunction>(spk_task), "spk_task", this);
+      res = (_task_handle != nullptr);
 #else
       size_t stack_size = 1280 + (_cfg.dma_buf_len * sizeof(uint32_t));
 
 #if portNUM_PROCESSORS > 1
       if (_cfg.task_pinned_core < portNUM_PROCESSORS)
       {
-        xTaskCreatePinnedToCore(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &_task_handle, _cfg.task_pinned_core);
+        res = (pdPASS == xTaskCreatePinnedToCore(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &_task_handle, _cfg.task_pinned_core));
       }
       else
 #endif
       {
-        xTaskCreate(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &_task_handle);
+        res = (pdPASS == xTaskCreate(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &_task_handle));
       }
 #endif
+      // end() takes the driver and the callback back down; it still sees the
+      // class as running, which is what lets it do that.
+      if (!res) { end(); }
     }
 
     return res;


### PR DESCRIPTION
Fixes #222.

## The race

`Mic_Class::isRecording()` gated the pending-length check on `_is_recording`, a flag that only `mic_task` sets, and only once it has been scheduled and found work to do. `record()` stores the request and notifies the task without touching the flag, so between the two the function answers 0 although a request is pending. The idiom the examples use

```cpp
if (M5.Mic.record(buf, len)) { while (M5.Mic.isRecording()) { M5.delay(1); } }
```

therefore falls straight through on the first call after an idle period, and the caller reads a buffer that still holds the previous recording — which is what the reporter heard as a metallic/robotic artifact. `Mic_Class::begin()` waits the same way before restarting the task at a new sample rate.

## The fix

The lengths alone already answer the question: `record()` fills one in before notifying the task, and the task zeroes it only after writing the last sample. So the flag is dropped from the condition, and with it the member, whose only reader this was.

This is how the speaker side has always worked — `Speaker_Class::isPlaying(uint8_t channel)` looks at its `wavinfo` entries with no flag involved — so the two sides now answer the same way. (The speaker reaches the same guarantee for its channel bits from the other direction: `_set_next_wav()` sets them in the calling context before notifying, and `spk_task` re-checks the data after clearing one.)

Two supporting changes come with it:

- `end()` now clears the requests, so one left unfinished by a stopped task cannot keep reporting a recording — the same thing `Speaker_Class::end()` does for its `wavinfo` entries.
- `isRecording()` is marked `volatile`, so the reads in a polling loop cannot be optimized away, matching the qualification the speaker's status methods already carry.

The documented return values (0 / 1 / 2) are unchanged.

## begin() reporting a failure

Dropping the flag exposed an existing gap: the result of the task creation was discarded, so a failure left the class believing it was running. Under the old condition `isRecording()` answered 0 in that state; under the new one the request would stay queued and the wait would never end. `begin()` now reports the failure, which turns it into the `false` that `record()` is already documented to return.

The speaker had the same gap in its `begin()`, and the last commit closes it there too. Playback itself already survives a failed task creation — `_play_raw()` returns before queueing when there is no task handle — so on that side it only corrects the answer `begin()` gives.

## Verification

Measured on an M5Stack CoreS3, filling the destination buffer with a sentinel before each `record()` and counting how much of it survives the wait loop (200 trials per case):

| | `isRecording()==0` right after `record()` | frames with sentinel left | worst frame |
|---|---|---|---|
| before, task at default priority | 1/200 | 1/200 | 512/512 samples |
| before, task at the caller's priority and core | 100/200 | 100/200 | 512/512 samples |
| after, both cases | 0 | 0 | 0 |

A worst frame of 512/512 means the wait returned before a single sample had been written. The 50% rate in the second case comes from the two states alternating: the request that was missed is still recorded afterwards, so the next call finds the task busy and waits correctly, and the one after that meets an idle task again.

Built for ESP32 (ESP-IDF 4.4), ESP32-S3 (ESP-IDF 5.0 and 5.5) and the SDL build.
