### PR TITLE
Publish a recording request with its length, not before it

### DIFF
--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -48,6 +48,7 @@
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <atomic>
 
 namespace m5
 {
@@ -570,18 +571,18 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 
     while (self->_task_running)
     {
-      bool rec_flip = self->_rec_flip;
+      bool rec_flip = self->_rec_flip.load(std::memory_order_relaxed);
       recording_info_t* current_rec = &(self->_rec_info[!rec_flip]);
       recording_info_t* next_rec    = &(self->_rec_info[ rec_flip]);
 
-      size_t dst_remain = current_rec->length;
+      size_t dst_remain = current_rec->length.load(std::memory_order_acquire);
       if (dst_remain == 0)
       {
         rec_flip = !rec_flip;
-        self->_rec_flip = rec_flip;
+        self->_rec_flip.store(rec_flip, std::memory_order_relaxed);
         xSemaphoreGive(self->_task_semaphore);
         std::swap(current_rec, next_rec);
-        dst_remain = current_rec->length;
+        dst_remain = current_rec->length.load(std::memory_order_acquire);
         if (dst_remain == 0)
         {
           ulTaskNotifyTake( pdTRUE, portMAX_DELAY );
@@ -592,7 +593,6 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
           continue;
         }
       }
-
       for (;;)
       {
         if (src_idx >= src_len)
@@ -695,7 +695,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
         dst_remain -= output_num;
         if ((int32_t)dst_remain <= 0)
         {
-          current_rec->length = 0;
+          current_rec->length.store(0, std::memory_order_release);
           break;
         }
       }
@@ -759,27 +759,48 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     }
 
     // an unfinished request would otherwise keep isRecording() reporting a recording.
-    _rec_info[0] = recording_info_t();
-    _rec_info[1] = recording_info_t();
+    _rec_info[0].clear();
+    _rec_info[1].clear();
 
     if (_cb_set_enabled) { _cb_set_enabled(_cb_set_enabled_args, false); }
     _i2s_driver_uninstall(_cfg.i2s_port);
   }
 
+  void Mic_Class::recording_info_t::clear(void)
+  {
+    data = nullptr;
+    index = 0;
+    is_stereo = false;
+    is_16bit = false;
+    length.store(0, std::memory_order_release);
+  }
+
   bool Mic_Class::_rec_raw(void* recdata, size_t array_len, bool flg_16bit, uint32_t sample_rate, bool flg_stereo)
   {
-    recording_info_t info;
-    info.data = recdata;
-    info.length = array_len;
-    info.is_16bit = flg_16bit;
-    info.is_stereo = flg_stereo;
-
     _cfg.sample_rate = sample_rate;
 
     if (!begin()) { return false; }
     if (array_len == 0) { return true; }
-    while (_rec_info[_rec_flip].length) { xSemaphoreTake(_task_semaphore, 1); }
-    _rec_info[_rec_flip] = info;
+    // The task moves the flip as it finishes a slot, so settle on one only
+    // once its own length says it is free, and keep that slot below.
+    bool flip;
+    for (;;)
+    {
+      flip = _rec_flip.load(std::memory_order_relaxed);
+      if (_rec_info[flip].length.load(std::memory_order_acquire) == 0) { break; }
+      xSemaphoreTake(_task_semaphore, 1);
+    }
+
+    // Assigning the whole struct would let the length reach the task ahead of
+    // the fields describing the data, and the task acts on a slot the moment
+    // the length is there. Fill those in first and publish with the length.
+    auto& slot = _rec_info[flip];
+    slot.data = recdata;
+    slot.index = 0;
+    slot.is_stereo = flg_stereo;
+    slot.is_16bit = flg_16bit;
+    slot.length.store(array_len, std::memory_order_release);
+
     if (this->_task_handle)
     {
       xTaskNotifyGive(this->_task_handle);

--- a/src/utility/Mic_Class.hpp
+++ b/src/utility/Mic_Class.hpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <stdint.h>
+#include <atomic>
 
 #ifndef I2S_PIN_NO_CHANGE
 #define I2S_PIN_NO_CHANGE (-1)
@@ -114,7 +115,7 @@ namespace m5
 
     /// now in recording or not.
     /// @return 0=not recording / 1=recording (There's room in the queue) / 2=recording (There's no room in the queue.)
-    size_t isRecording(void) const volatile { return ((bool)_rec_info[0].length) + ((bool)_rec_info[1].length); }
+    size_t isRecording(void) const volatile { return ((bool)_rec_info[0].length.load(std::memory_order_acquire)) + ((bool)_rec_info[1].length.load(std::memory_order_acquire)); }
 
     /// set recording sampling rate.
     /// @param sample_rate the sampling rate (Hz)
@@ -163,14 +164,23 @@ namespace m5
     struct recording_info_t
     {
       void* data = nullptr;
-      size_t length = 0;
+      /// The task takes a slot as soon as this is set, so it is stored last
+      /// with a release and loaded first with an acquire: that is what makes
+      /// the fields above visible to the task, and the recorded samples
+      /// visible to whoever waits for the slot to come back empty. It is also
+      /// why the slot cannot be copied as a whole.
+      std::atomic<size_t> length { 0 };
       size_t index = 0;
       bool is_stereo = false;
       bool is_16bit = false;
+
+      void clear(void);
     };
 
     recording_info_t _rec_info[2];
-    volatile bool _rec_flip = false;
+    /// Which of the two slots the next request goes into. The task moves it;
+    /// a writer picks it up once and stays with that slot.
+    std::atomic<bool> _rec_flip { false };
 
     static void mic_task(void* args);
 


### PR DESCRIPTION
Follow-up to #293, on the same slot handover.

## What goes wrong

`record()` hands its request to `mic_task` by assigning the whole `recording_info_t` into the slot the task polls. The compiler turns that into a `memcpy` (14 bytes, confirmed by disassembly), and the length sits in the middle of it. The task treats a non-zero length as "this slot is ready", so it can pick a slot up while the rest is still being copied — with the data pointer and the sample format of the *previous* request. A 16-bit format left over from before makes it write twice as far as the caller's buffer allows.

Nothing about this is theoretical for the ordering either: `memcpy` gives no guarantee about which bytes land first, and the two cores give none about the order they become visible in.

## The fix

The fields describing the request go in first, and the length publishes the slot last — which is what the length already means to the task.

The length becomes a `std::atomic<size_t>`, stored with `memory_order_release` and loaded with `memory_order_acquire`. That is what makes the preceding stores visible to the task once it observes the length; plain stores promise nothing between cores. A `volatile` marker would not be enough either: it leaves the surrounding ordinary accesses unordered, and on the RISC-V targets it emits no barrier at all (on Xtensa it happens to emit `memw`, which is where the assumption usually survives). The generated code was checked on both: `fence rw,w` / `fence r,rw` on RISC-V, `memw` on Xtensa, with the accesses inlined — no calls into libatomic.

A slot can no longer be copied as a whole, so `end()` clears one through a `clear()` of its own.

## Verification

On an M5Stack CoreS3, with the recording buffer filled with a sentinel before each `record()` and the survivors counted after the wait loop, 200 trials per case: no false completions, no dirty frames, no timeouts — the same as before this change, which is what is expected. This corrects a window that is hard to hit on purpose rather than one that shows up in a loop.

Built for ESP32 (ESP-IDF 4.4), ESP32-S3 (ESP-IDF 5.5), ESP32-C6 (RISC-V) and the SDL build.

## Not included

The speaker side hands its requests over the same way and has the same problem. Fixing it properly means more than reordering the stores: `spk_task` reads several fields of a slot *before* deciding to take it, and a stop request skips the wait for the slot to be free, so a "the slot is filled" marker alone does not hold there. That needs its own change to the handover protocol, so it is left out of this one.
