### PR TITLE
Add support for M5Stack ToughC5 (ESP32-C5)

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -124,6 +124,7 @@ static constexpr const uint8_t _pin_table_i2c_ex_in[][5] = {
 { board_t::board_unknown      , 255        ,255         , 255        ,255         },
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
 { board_t::board_M5StampC5    , 255        ,255         , 255        ,255         },
+{ board_t::board_M5ToughC5    , GPIO_NUM_3 ,GPIO_NUM_2  , GPIO_NUM_3 ,GPIO_NUM_2  }, // PortA は内部バスと同一 (レベルシフタ経由の物理分配)
 { board_t::board_unknown      , 255        ,255         , 255        ,255         },
 #else
 { board_t::board_M5Stack      , GPIO_NUM_22,GPIO_NUM_21 , GPIO_NUM_22,GPIO_NUM_21 },
@@ -157,6 +158,7 @@ static constexpr const uint8_t _pin_table_port_bc[][5] = {
 #elif defined (CONFIG_IDF_TARGET_ESP32P4)
 { board_t::board_M5Tab5       , GPIO_NUM_17,GPIO_NUM_52, GPIO_NUM_7 ,GPIO_NUM_6  }, // Tab5
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
+{ board_t::board_M5ToughC5    , GPIO_NUM_1 ,GPIO_NUM_6  , GPIO_NUM_12,GPIO_NUM_11 },
 #else
 { board_t::board_M5Stack      , GPIO_NUM_36,GPIO_NUM_26 , GPIO_NUM_16,GPIO_NUM_17 },
 { board_t::board_M5StackCore2 , GPIO_NUM_36,GPIO_NUM_26 , GPIO_NUM_13,GPIO_NUM_14 },
@@ -206,6 +208,7 @@ static constexpr const uint8_t _pin_table_sd[][7] = {
 #elif defined (CONFIG_IDF_TARGET_ESP32P4)
 { board_t::board_M5Tab5       , GPIO_NUM_43, GPIO_NUM_44, GPIO_NUM_39, GPIO_NUM_40, GPIO_NUM_41, GPIO_NUM_42 },
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
+{ board_t::board_M5ToughC5    , GPIO_NUM_9 , GPIO_NUM_7 , GPIO_NUM_8 , 255        , 255        , GPIO_NUM_10 },
 #else
 { board_t::board_M5Stack      , GPIO_NUM_18, GPIO_NUM_23, GPIO_NUM_19, 255        , 255        , GPIO_NUM_4  },
 { board_t::board_M5StackCore2 , GPIO_NUM_18, GPIO_NUM_23, GPIO_NUM_38, 255        , 255        , GPIO_NUM_4  },
@@ -2933,6 +2936,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       {
       case board_t::board_M5StackCore2:
       case board_t::board_M5Tough:
+      case board_t::board_M5ToughC5:
       case board_t::board_M5StackCoreS3SE:
       case board_t::board_M5StackCoreS3:
       case board_t::board_M5StackChan:
@@ -3241,7 +3245,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       }
     }
 
-#if defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S3)
+#if defined (CONFIG_IDF_TARGET_ESP32) || defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C5)
     if (_use_pmic_button)
     {
       Button_Class::button_state_t state = Button_Class::button_state_t::state_nochange;
@@ -3267,6 +3271,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     {
     case board_t::board_M5StackCore2:
     case board_t::board_M5Tough:
+    case board_t::board_M5ToughC5:
     case board_t::board_M5StackCoreS3SE:
     case board_t::board_M5StackCoreS3:
     case board_t::board_M5StackChan:

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1778,6 +1778,18 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     i2c_port_t ex_port = I2C_NUM_0;
 #if SOC_I2C_NUM == 1 || defined (CONFIG_IDF_TARGET_ESP32C6) || defined (CONFIG_IDF_TARGET_ESP32C5)
     i2c_port_t in_port = I2C_NUM_0;
+// M5GFX が LP_I2C 対応をコンパイルする条件と同一に保つこと
+// (条件を満たさない SDK では LP ポートを開けないため HP のまま運用する)
+#if defined (CONFIG_IDF_TARGET_ESP32C5) && defined ( SOC_LP_I2C_NUM ) && ( SOC_LP_I2C_NUM > 0 ) \
+ && __has_include ( <driver/i2c_master.h> ) && defined ( ESP_IDF_VERSION_VAL ) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    if (board == board_t::board_M5ToughC5)
+    { /// 内部バス (G2/G3) は LP_I2C の固定パッドと一致するため LP ポートへ割り当てる。
+      /// PortA も同じバスの物理分配なので Ex_I2C は同ポートを共有し (初代 BASIC と
+      /// 同じ形)、HP の I2C0 は丸ごと空く。
+      in_port = LP_I2C_NUM_0;
+      ex_port = LP_I2C_NUM_0;
+    }
+#endif
 #else
     i2c_port_t in_port = I2C_NUM_1;
     if (in_scl == ex_scl && in_sda == ex_sda) {

--- a/src/M5Unified.hpp
+++ b/src/M5Unified.hpp
@@ -167,6 +167,8 @@ namespace m5
                              = board_t::board_M5StampC3;
 #elif defined (CONFIG_IDF_TARGET_ESP32P4)
                              = board_t::board_M5Tab5;
+#elif defined (CONFIG_IDF_TARGET_ESP32C5)
+                             = board_t::board_M5StampC5;
 #elif defined (CONFIG_IDF_TARGET_ESP32) || !defined (CONFIG_IDF_TARGET)
                              = board_t::board_M5AtomLite;
 #else

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -217,6 +217,24 @@ namespace m5
       break;
     }
 
+#elif defined (CONFIG_IDF_TARGET_ESP32C5)
+
+    /// setup power management ic
+    switch (M5.getBoard())
+    {
+    default:
+      break;
+
+    case board_t::board_M5ToughC5:
+      _pmic = pmic_t::pmic_m5pm1;
+      _wakeupPin = GPIO_NUM_4;
+      M5pm1.setBatteryCharge(true);
+      M5pm1.setDCDCOutput(true);
+      M5pm1.setLDOOutput(true);
+      M5pm1.setLedEnLevel(true);
+      break;
+    }
+
 #elif defined (CONFIG_IDF_TARGET_ESP32S3)
 
     /// setup power management ic
@@ -672,7 +690,7 @@ namespace m5
 
 #endif
 
-#if defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C61)
+#if defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined (CONFIG_IDF_TARGET_ESP32C5)
     if (_pmic == pmic_t::pmic_m5pm1)
     {
       M5pm1.begin();
@@ -747,6 +765,14 @@ namespace m5
 #elif defined (CONFIG_IDF_TARGET_ESP32C6)
     case board_t::board_ArduinoNessoN1:
       M5.getIOExpander(1).digitalWrite(2, enable); // 2 = EXT_PWR_EN
+      break;
+
+#elif defined (CONFIG_IDF_TARGET_ESP32C5)
+    case board_t::board_M5ToughC5:
+      if (_pmic == pmic_t::pmic_m5pm1)
+      {
+        M5pm1.setExtOutput(enable);
+      }
       break;
 
 #elif defined (CONFIG_IDF_TARGET_ESP32H2)
@@ -922,6 +948,11 @@ namespace m5
     case board_t::board_M5StampS3Bat:
       return M5pm1.getGPIOOutputLatch(M5PM1_Class::gpio1);
       break;
+#elif defined (CONFIG_IDF_TARGET_ESP32C5)
+    case board_t::board_M5ToughC5:
+      return M5pm1.getExtOutput();
+      break;
+
 #elif !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
     case board_t::board_M5Paper:
       return m5gfx::gpio_in(M5Paper_EXT5V_ENABLE_PIN);
@@ -1163,7 +1194,7 @@ namespace m5
         }
         break;
 
-#elif defined (CONFIG_IDF_TARGET_ESP32C61)
+#elif defined (CONFIG_IDF_TARGET_ESP32C61) || defined (CONFIG_IDF_TARGET_ESP32C5)
       case pmic_t::pmic_m5pm1:
         if (!withTimer) {
           M5pm1.powerOff();
@@ -1629,7 +1660,7 @@ namespace m5
       f = Axp2101.getVBUSVoltage();
       break;
 
-#if defined (CONFIG_IDF_TARGET_ESP32S3)
+#if defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C5)
     case pmic_t::pmic_m5pm1:
       f = M5pm1.getVBUSVoltage() / 1000.0f;
       break;
@@ -1674,7 +1705,7 @@ namespace m5
     case pmic_t::pmic_axp2101:
       return Axp2101.getBatteryVoltage() * 1000;
 
-#if defined (CONFIG_IDF_TARGET_ESP32S3)
+#if defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C5)
     case pmic_t::pmic_m5pm1:
       return M5pm1.getBatteryVoltage();
 #endif
@@ -1739,7 +1770,7 @@ namespace m5
       return Axp2101.getBatteryLevel();
       break;
 
-#if defined (CONFIG_IDF_TARGET_ESP32S3)
+#if defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C5)
     case pmic_t::pmic_m5pm1:
       {
         // Get battery voltage in mV
@@ -1812,12 +1843,13 @@ namespace m5
       Axp2101.setBatteryCharge(enable);
       break;
 
-#if defined (CONFIG_IDF_TARGET_ESP32S3)
+#if defined (CONFIG_IDF_TARGET_ESP32S3) || defined (CONFIG_IDF_TARGET_ESP32C5)
     case pmic_t::pmic_m5pm1:
       {
+#if defined (CONFIG_IDF_TARGET_ESP32S3)
         // M5PaperColor does not support charge control
         if (M5.getBoard() == board_t::board_M5PaperColor) {
-            return;
+          return;
         }
         // M5PaperMono: charging is controlled by the IP2316 charger, not PM1.
         if (M5.getBoard() == board_t::board_M5PaperMono) {
@@ -1829,6 +1861,7 @@ namespace m5
           set_papermono_ip2315_enabled(false);
           return;
         }
+#endif
         M5pm1.setBatteryCharge(enable);
       }
       return;
@@ -2217,7 +2250,7 @@ namespace m5
     case pmic_t::pmic_m5pm1:
       return M5pm1.getPekPress();
 
-#elif defined (CONFIG_IDF_TARGET_ESP32C61)
+#elif defined (CONFIG_IDF_TARGET_ESP32C61) || defined (CONFIG_IDF_TARGET_ESP32C5)
     case pmic_t::pmic_m5pm1:
       return M5pm1.getPekPress();
 

--- a/src/utility/Power_Class.hpp
+++ b/src/utility/Power_Class.hpp
@@ -240,6 +240,10 @@ namespace m5
     // secondery INA3221 for M5Station.
     INA3221_Class Ina3221[2] = { { 0x40 }, { 0x41 } };
 
+#if defined (CONFIG_IDF_TARGET_ESP32C5)
+    M5PM1_Class M5pm1;
+#endif
+
 #endif
 
   private:

--- a/src/utility/RTC_Class.cpp
+++ b/src/utility/RTC_Class.cpp
@@ -49,6 +49,12 @@ namespace m5
         break;
 #endif
 
+#if defined (CONFIG_IDF_TARGET_ESP32C5)
+      case board_t::board_M5ToughC5:
+        instance.reset(new RX8130_Class(RX8130_Class::DEFAULT_ADDRESS, 400000, i2c));
+        break;
+#endif
+
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
       case board_t::board_M5PowerHub:
         instance.reset(new RTC_PowerHub_Class(RTC_PowerHub_Class::DEFAULT_ADDRESS, 400000));

--- a/src/utility/power/M5PM1_Class.cpp
+++ b/src/utility/power/M5PM1_Class.cpp
@@ -38,8 +38,10 @@ namespace m5
   static constexpr const uint8_t M5PM1_REG_IRQ_MASK3   = 0x45;
 
   static constexpr const uint8_t M5PM1_PWR_CFG_CHG_EN   = 1 << 0;
+  static constexpr const uint8_t M5PM1_PWR_CFG_DCDC_EN  = 1 << 1;
   static constexpr const uint8_t M5PM1_PWR_CFG_LDO_EN   = 1 << 2;
   static constexpr const uint8_t M5PM1_PWR_CFG_BOOST_EN = 1 << 3;
+  static constexpr const uint8_t M5PM1_PWR_CFG_LED_EN   = 1 << 4;
   static constexpr const uint8_t M5PM1_SYS_CMD_SHUTDOWN = 0xA1;
 
   static constexpr bool is_valid_gpio(M5PM1_Class::gpio_t pin)
@@ -83,6 +85,16 @@ namespace m5
   {
     return enable ? bitOn(M5PM1_REG_PWR_CFG, M5PM1_PWR_CFG_LDO_EN)
                   : bitOff(M5PM1_REG_PWR_CFG, M5PM1_PWR_CFG_LDO_EN);
+  }
+  bool M5PM1_Class::setDCDCOutput(bool enable)
+  {
+    return enable ? bitOn(M5PM1_REG_PWR_CFG, M5PM1_PWR_CFG_DCDC_EN)
+                  : bitOff(M5PM1_REG_PWR_CFG, M5PM1_PWR_CFG_DCDC_EN);
+  }
+  bool M5PM1_Class::setLedEnLevel(bool level)
+  {
+    return level ? bitOn(M5PM1_REG_PWR_CFG, M5PM1_PWR_CFG_LED_EN)
+                 : bitOff(M5PM1_REG_PWR_CFG, M5PM1_PWR_CFG_LED_EN);
   }
 
   M5PM1_Class::pwr_src_t M5PM1_Class::getPowerSource(void)

--- a/src/utility/power/M5PM1_Class.hpp
+++ b/src/utility/power/M5PM1_Class.hpp
@@ -74,6 +74,14 @@ namespace m5
     /// @param enable true=enable / false=disable
     bool setLDOOutput(bool enable);
 
+    /// set PM1 5V DCDC output enable.
+    /// @param enable true=enable / false=disable
+    bool setDCDCOutput(bool enable);
+
+    /// set the default level of the PM1 LED_EN pin.
+    /// @param level true=high / false=low
+    bool setLedEnLevel(bool level);
+
     /// get current PM1 power source.
     pwr_src_t getPowerSource(void);
 


### PR DESCRIPTION
Adds board support for the M5Stack ToughC5: the pin tables (I2C, PortB / PortC, SD), the RX8130 RTC, and power management through M5PM1_Class (PMIC setup on begin, the external 5V rail, battery readings, the power button and powerOff). M5PM1_Class gains the DCDC / LED_EN controls the board needs. The board carries a display and is identified as such by M5GFX.

Port A is a level-shifted branch of the internal I2C bus (SDA=G2 / SCL=G3), the way the original M5Stack shares its internal and external I2C. Those pins are exactly the C5's fixed LP_I2C pads, so In_I2C and Ex_I2C both run on the low power port, which leaves the C5's single high power I2C controller entirely free for user code. On an SDK without the low power support (pre-5.4 ESP-IDF) everything stays on the high power port.

Pairs with m5stack/M5GFX#238 (backlight / touch on the same port); the two should land together. Verified on the actual board.
