### PR TITLE
Remove BMM150 support from Chain Captain

### DIFF
--- a/src/utility/IMU_Class.cpp
+++ b/src/utility/IMU_Class.cpp
@@ -107,7 +107,6 @@ namespace m5
         { // ChainCaptain BMI270 : X=-Y, Y=-X, Z=-Z
           _internal_axisorder_fixed[sensor_index_accel] = (internal_axisorder_t)(axis_order_yxz | axis_invert_x | axis_invert_y | axis_invert_z);
           _internal_axisorder_fixed[sensor_index_gyro ] = (internal_axisorder_t)(axis_order_yxz | axis_invert_x | axis_invert_y | axis_invert_z);
-          _internal_axisorder_fixed[sensor_index_mag  ] = (internal_axisorder_t)(axis_order_yxz | axis_invert_x | axis_invert_y | axis_invert_z);
         }
 #endif
 


### PR DESCRIPTION
BMM150 has been discontinued, so remove related driver and support code.