### PR TITLE
Harden the PM1 sleep/power-off paths: safe failure behavior and begin-time IRQ normalization

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -2900,8 +2900,9 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     }
   }
 
-  void M5Unified::_clearWakeupInterrupt(void)
+  bool M5Unified::_clearWakeupInterrupt(void)
   {
+    bool res = true;
     // A touch panel holds its INT asserted until the touch data is read. Every board that
     // uses the touch INT as its wakeup pin therefore has to consume the data here.
     // ( M5Paper = GPIO36 , M5PaperS3 = GPIO48 , Core2 / Tough = GPIO39 , CoreS3 = via AW9523 )
@@ -2922,7 +2923,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
         // its input would stay in the touched state and a later touch would not produce
         // any change, leaving the wakeup source dead.
         uint8_t buf[2];
-        In_I2C.readRegister(aw9523_i2c_addr, 0x00, buf, sizeof(buf), 400000);
+        res = In_I2C.readRegister(aw9523_i2c_addr, 0x00, buf, sizeof(buf), 400000);
       }
       break;
 
@@ -2938,8 +2939,8 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
         // 全て 0 になるまで Low を保つため、ここでクリアして解放する。
         // WAKE_SRC が残っていると IRQ Status 3 の WAKEUP ビットが再セット
         // され続けるので、先に WAKE_SRC を消す。
-        Power.M5pm1.clearWakeSource();
-        Power.M5pm1.clearIRQStatus();
+        res  = Power.M5pm1.clearWakeSource();
+        res &= Power.M5pm1.clearIRQStatus();
       }
       break;
 
@@ -2955,8 +2956,8 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
         // IRQ status bit is cleared, so clear them here to release the pin.
         // Clear WAKE_SRC first: while it is set, the WAKEUP bit of IRQ status 3
         // keeps getting re-asserted.
-        Power.M5pm1.clearWakeSource();
-        Power.M5pm1.clearIRQStatus();
+        res  = Power.M5pm1.clearWakeSource();
+        res &= Power.M5pm1.clearIRQStatus();
       }
       break;
 
@@ -2964,6 +2965,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       break;
     }
 #endif
+    return res;
   }
 
   bool M5Unified::_begin_rtc_imu(const config_t& cfg)

--- a/src/M5Unified.hpp
+++ b/src/M5Unified.hpp
@@ -641,7 +641,8 @@ namespace m5
     /// interrupt expander only reports changes, so both have to be consumed.
     /// Otherwise the wakeup pin stays asserted and no further event can wake the device.
     /// @attention For internal use. Called from Power_Class immediately before sleeping.
-    void _clearWakeupInterrupt(void);
+    /// @return false when clearing required communication with a device and it failed.
+    bool _clearWakeupInterrupt(void);
 
     static constexpr std::size_t BTNPWR_MIN_UPDATE_MSEC = 4;
 

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -257,6 +257,14 @@ namespace m5
     case board_t::board_M5ToughC5:
       _pmic = pmic_t::pmic_m5pm1;
       _wakeupPin = GPIO_NUM_4;
+      /// PM1 は常時給電で ESP のリセットを跨いで状態が残るため、直前に動いて
+      /// いたファームの設定に依存しないよう IRQ 関連を初期化する
+      M5pm1.clearWakeSource();
+      M5pm1.clearIRQStatus();
+      M5pm1.setGPIOIRQMaskBits(0x16);  // enable GPIO0(TP INT)/GPIO3(RTC nIRQ), disable other GPIO IRQ
+      /// PM1 GPIO0 は TP INT 入力。
+      M5pm1.setGPIOFunction(M5PM1_Class::gpio0, M5PM1_Class::gpio);
+      M5pm1.setGPIOMode(M5PM1_Class::gpio0, M5PM1_Class::input);
       M5pm1.setBatteryCharge(true);
       M5pm1.setDCDCOutput(true);
       M5pm1.setLDOOutput(true);

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1403,14 +1403,19 @@ namespace m5
     _powerOff(true);
   }
 
-  bool Power_Class::_releaseWakeupPin(std::uint_fast8_t wakeup_pin)
+  bool Power_Class::_releaseWakeupPin(std::uint_fast8_t wakeup_pin, bool* clear_comm_ok)
   {
+    // clear_comm_ok は「割り込み要因のクリア通信が一度でも成功したか」を返す。
+    // ピンが解放されない理由が「要因がまだ生きている (指が触れている等)」なのか
+    // 「デバイスと通信できない (回復見込みなし)」なのかを呼び出し元が区別できる。
+    bool comm_ok = false;
     for (int retry = 8; retry > 0; --retry)
     {
-      if (m5gfx::gpio_in(wakeup_pin)) { return true; }
-      M5._clearWakeupInterrupt();
+      if (m5gfx::gpio_in(wakeup_pin)) { if (clear_comm_ok) { *clear_comm_ok = true; } return true; }
+      comm_ok |= M5._clearWakeupInterrupt();
       m5gfx::delay(5);
     }
+    if (clear_comm_ok) { *clear_comm_ok = comm_ok; }
     return m5gfx::gpio_in(wakeup_pin);
   }
 
@@ -1494,8 +1499,17 @@ namespace m5
 #endif
       if (pin_wakeup_enabled)
       {
-        while (!_releaseWakeupPin(wpin))
+        bool clear_comm_ok = true;
+        while (!_releaseWakeupPin(wpin, &clear_comm_ok))
         {
+          if (!clear_comm_ok)
+          { // 割り込み要因のクリア通信自体が失敗している。解放されない線を
+            // ANY_LOW で待つ構成のまま眠ると即時復帰の再起動ループになるため、
+            // 眠らずに戻る。( 要因が生きているだけなら従来通り解放を待つ )
+            M5_LOGE("deepSleep: cannot release the wakeup pin. not sleeping.");
+            M5.Display.wakeup();
+            return;
+          }
           // Issue #91, ( M5Paper wakes too soon from deep sleep when touch wakeup is enabled - with solution )
           M5.update();
           m5gfx::delay(10);
@@ -1581,7 +1595,17 @@ namespace m5
       }
       if (pin_wakeup_enabled)
       { // Wait until the wakeup pin is released, otherwise the sleep request is rejected.
-        while (!_releaseWakeupPin(wpin)) { m5gfx::delay(10); }
+        bool clear_comm_ok = true;
+        while (!_releaseWakeupPin(wpin, &clear_comm_ok))
+        {
+          if (!clear_comm_ok)
+          { // クリア通信自体が失敗している場合は解放を待たない。light sleep は
+            // 即時復帰しても実行が戻るだけなので deep sleep と違い眠って構わない
+            M5_LOGE("lightSleep: cannot release the wakeup pin.");
+            break;
+          }
+          m5gfx::delay(10);
+        }
       }
       else
       {

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1259,31 +1259,58 @@ namespace m5
 
 #elif defined (CONFIG_IDF_TARGET_ESP32C61) || defined (CONFIG_IDF_TARGET_ESP32C5)
       case pmic_t::pmic_m5pm1:
+      {
+        bool arm_wakeup = withTimer;
         if (!withTimer) {
-          M5pm1.powerOff();
+          int retry = 3;
+          while (!M5pm1.powerOff() && --retry) { m5gfx::delay(10); }
+          if (!retry)
+          { /// 電源を落とせないまま wake source 無しで眠ると、電源ボタンの単押しや
+            /// IRQ では復帰できなくなる (PM1 の二重クリックや USB 再接続による
+            /// 電源サイクルは可能)。単押しで復帰できるよう IRQ ピンを残して眠る
+            M5_LOGE("_powerOff: M5PM1 powerOff failed.");
+            arm_wakeup = true;
+          }
         }
 #if SOC_PM_SUPPORT_EXT1_WAKEUP
-        else if (_wakeupPin < GPIO_NUM_MAX)
+        if (arm_wakeup && _wakeupPin < GPIO_NUM_MAX)
         { /// RTC の nIRQ は ESP32 に直結されておらず PM1 の IRQ 出力に集約される
-          /// 構成 (ToughC5 等)。IRQ 出力が解放される (High に戻る) まで待って
-          /// から眠り、その Low 遷移で deep sleep から復帰できるようにする。
-          if (ESP_OK != esp_sleep_enable_ext1_wakeup(1ULL << _wakeupPin, ESP_EXT1_WAKEUP_ANY_LOW))
-          {
-            M5_LOGW("_powerOff: GPIO%d cannot be used as a wakeup source.", (int)_wakeupPin);
-          }
-#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
-          if (rtc_gpio_is_valid_gpio((gpio_num_t)_wakeupPin))
-          { /// IRQ 線には外部プルアップが無いため、deep sleep 中も有効な
-            /// RTC ドメインのプルアップで High を維持する
-            rtc_gpio_pullup_en((gpio_num_t)_wakeupPin);
-            rtc_gpio_pulldown_dis((gpio_num_t)_wakeupPin);
-          }
-#endif
+          /// 構成 (ToughC5 等)。IRQ 出力が解放される (High に戻る) のを確認して
+          /// から ANY_LOW を武装して眠り、その Low 遷移で deep sleep から復帰
+          /// できるようにする。
           int retry = 40;
           while (!_releaseWakeupPin(_wakeupPin) && --retry) { m5gfx::delay(10); }
+          if (!retry)
+          {
+            if (withTimer)
+            { /// 解放されない線を ANY_LOW で武装したまま眠ると即時復帰の
+              /// 再起動ループになるため、wake 経路を確保できなければ眠らない
+              M5_LOGE("_powerOff: cannot release the wakeup pin. not sleeping.");
+              M5.Display.wakeup();
+              return;
+            }
+            /// powerOff 失敗時の fallback では武装せず従来通り眠る (ログのみ)
+            M5_LOGE("_powerOff: cannot release the wakeup pin.");
+          }
+          else
+          {
+            if (ESP_OK != esp_sleep_enable_ext1_wakeup(1ULL << _wakeupPin, ESP_EXT1_WAKEUP_ANY_LOW))
+            {
+              M5_LOGW("_powerOff: GPIO%d cannot be used as a wakeup source.", (int)_wakeupPin);
+            }
+#if SOC_RTCIO_INPUT_OUTPUT_SUPPORTED
+            if (rtc_gpio_is_valid_gpio((gpio_num_t)_wakeupPin))
+            { /// IRQ 線には外部プルアップが無いため、deep sleep 中も有効な
+              /// RTC ドメインのプルアップで High を維持する
+              rtc_gpio_pullup_en((gpio_num_t)_wakeupPin);
+              rtc_gpio_pulldown_dis((gpio_num_t)_wakeupPin);
+            }
+#endif
+          }
         }
 #endif
         break;
+      }
 #endif
 
       case pmic_t::pmic_unknown:

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -1440,7 +1440,7 @@ namespace m5
 
   bool Power_Class::_releaseWakeupPin(std::uint_fast8_t wakeup_pin, bool* clear_comm_ok)
   {
-    // clear_comm_ok は「割り込み要因のクリア通信が一度でも成功したか」を返す。
+    // clear_comm_ok は「この呼び出し内でクリア通信が一度でも成功したか」を返す。
     // ピンが解放されない理由が「要因がまだ生きている (指が触れている等)」なのか
     // 「デバイスと通信できない (回復見込みなし)」なのかを呼び出し元が区別できる。
     bool comm_ok = false;
@@ -1535,16 +1535,23 @@ namespace m5
       if (pin_wakeup_enabled)
       {
         bool clear_comm_ok = true;
+        int comm_fail = 0;
         while (!_releaseWakeupPin(wpin, &clear_comm_ok))
         {
           if (!clear_comm_ok)
           { // 割り込み要因のクリア通信自体が失敗している。解放されない線を
             // ANY_LOW で待つ構成のまま眠ると即時復帰の再起動ループになるため、
-            // 眠らずに戻る。( 要因が生きているだけなら従来通り解放を待つ )
-            M5_LOGE("deepSleep: cannot release the wakeup pin. not sleeping.");
-            M5.Display.wakeup();
-            return;
+            // 失敗が連続する場合は眠らずに戻る。一時的な失敗 (デバイスの
+            // ビジー等) は許容し、成功が挟まれば数え直す。
+            // ( 要因が生きているだけなら従来通り解放を待つ )
+            if (++comm_fail >= 3)
+            {
+              M5_LOGE("deepSleep: cannot release the wakeup pin. not sleeping.");
+              M5.Display.wakeup();
+              return;
+            }
           }
+          else { comm_fail = 0; }
           // Issue #91, ( M5Paper wakes too soon from deep sleep when touch wakeup is enabled - with solution )
           M5.update();
           m5gfx::delay(10);
@@ -1631,14 +1638,19 @@ namespace m5
       if (pin_wakeup_enabled)
       { // Wait until the wakeup pin is released, otherwise the sleep request is rejected.
         bool clear_comm_ok = true;
+        int comm_fail = 0;
         while (!_releaseWakeupPin(wpin, &clear_comm_ok))
         {
           if (!clear_comm_ok)
-          { // クリア通信自体が失敗している場合は解放を待たない。light sleep は
+          { // クリア通信の失敗が連続する場合は解放を待たない。light sleep は
             // 即時復帰しても実行が戻るだけなので deep sleep と違い眠って構わない
-            M5_LOGE("lightSleep: cannot release the wakeup pin.");
-            break;
+            if (++comm_fail >= 3)
+            {
+              M5_LOGE("lightSleep: cannot release the wakeup pin.");
+              break;
+            }
           }
+          else { comm_fail = 0; }
           m5gfx::delay(10);
         }
       }

--- a/src/utility/Power_Class.hpp
+++ b/src/utility/Power_Class.hpp
@@ -261,7 +261,7 @@ namespace m5
 
     /// Release the wakeup pin so that it can be asserted again while sleeping.
     /// @return true if the pin is released ( high ).
-    bool _releaseWakeupPin(std::uint_fast8_t wakeup_pin);
+    bool _releaseWakeupPin(std::uint_fast8_t wakeup_pin, bool* clear_comm_ok = nullptr);
     float _readExtValue(ext_port_mask_t port_mask, bool is_voltage);
 
     float _adc_ratio = 0;


### PR DESCRIPTION
Hardens the sleep and power-off paths of the PM1-based wake configuration (ToughC5 and friends), following up on a review of the ToughC5 support.

## Problems

1. On boards where every wake source is funneled into the PM1 IRQ output, `deepSleep()` waits for that line to be released before arming EXT1 ANY_LOW. The wait could not tell "the wakeup source is still active (finger on the panel)" apart from "the clear communication itself is failing" — the former is a legitimate indefinite wait (Issue #91), the latter never resolves.
2. The timer sleep path armed EXT1 ANY_LOW *before* waiting for the release, so a failed release still went to sleep on a low line and rebooted immediately, in a loop.
3. `powerOff()` ignored the result of the PM1 shutdown command and proceeded to a wake-less deep sleep. The device stays recoverable through the PM1 itself (double-click of the power button, or replugging USB, power-cycles the ESP32), but a single press could no longer wake it and nothing was logged.
4. The PM1 keeps running across ESP32 resets, so IRQ masks and pin modes survive from whatever firmware ran before; the ToughC5 setup did not normalize them, unlike the PaperMono setup.

## Changes (one commit each)

1. **Distinguish a dead wakeup-clear path from an active wakeup source** — `_clearWakeupInterrupt()` reports whether clearing could communicate; `deepSleep()` still waits indefinitely for an active source exactly as before, but stays awake (with an error log) when the communication fails. `lightSleep()` just stops waiting in that case, since an immediate wakeup from light sleep is harmless.
2. **Arm the PM1 wakeup pin only after it has been released, and retry powerOff** — release first, arm second; when the wake path cannot be secured, the timer path stays awake instead of reboot-looping. The shutdown command is retried, and its fallback sleep keeps the IRQ pin armed so a single button press can wake the device.
3. **Normalize the PM1 IRQ state of the ToughC5 at begin** — clear wake source / IRQ status, mask unused GPIO IRQs, return GPIO0 (touch INT) to a plain input; same treatment as PaperMono.

## Notes on shared paths

- `_clearWakeupInterrupt()` changed from `void` to `bool`; the CoreS3 (AW9523) branch now returns the read result. No behavioral change for any board when communication works.
- The M5Paper "wait until the finger is lifted" semantic of `deepSleep()` is preserved unchanged.

## Testing

- ToughC5 device: deep sleep and wake through touch, power button and RTC alarm; cold start from full power removal; normal operation regression on display/touch/RTC/TF pages.
- Regression build for the ESP32 target (Core2) alongside the ESP32-C5 target.
