### PR TITLE
Add esp32c5 to the ESP-IDF build matrix

### DIFF
--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -37,6 +37,9 @@ jobs:
             idf_version: "5.3"
           - target: esp32c3
             idf_version: "5.1.6"
+          # ESP32-C5 (IDF 5.5+ only)
+          - target: esp32c5
+            idf_version: "5.5.2"
           # ESP32-C6 (IDF 5.3+ only)
           - target: esp32c6
             idf_version: "5.3"


### PR DESCRIPTION
The library supports ESP32-C5 boards, but the ESP-IDF CI matrix did not cover the esp32c5 target.

This adds an esp32c5 entry built with IDF 5.5.2 (the first release line that supports the C5), matching the style of the existing esp32c61 entry.

Verified locally: `examples/Test/build_test` builds cleanly for `esp32c5` with ESP-IDF v5.5.3 (no warnings from M5Unified/M5GFX sources).