### PR TITLE
CI: add esp32c5 to the Arduino build matrix and cancel superseded runs

### DIFF
--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.board }} (${{ matrix.esp32_version }})
@@ -44,6 +49,11 @@ jobs:
           - board: esp32:esp32:esp32c3
             esp32_version: 3.1.1
             board_manager_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          # ESP32-C5 (v3.3+ only)
+          - board: esp32:esp32:esp32c5
+            esp32_version: 3.3.11
+            board_manager_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+
           # ESP32-C6 (v3 only)
           - board: esp32:esp32:esp32c6
             esp32_version: 3.1.1

--- a/.github/workflows/IDFBuild.yml
+++ b/.github/workflows/IDFBuild.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# supersede queued/running builds of the same branch or PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.target }} (IDF ${{ matrix.idf_version }})


### PR DESCRIPTION
## Summary

- The Arduino build matrix gains **esp32c5 on arduino-esp32 3.3.11** (C5 support landed in the 3.3 series), closing the gap where C5 was only covered on the ESP-IDF side of the matrix.
- Both build workflows now **cancel superseded runs** of the same branch or pull request. The concurrency group is keyed by event name and PR number, so runs from different forks (or a scheduled run) cannot cancel each other.

## Testing

- Fork run of the extended matrix: all Arduino jobs green including the new `esp32c5 (3.3.11)`, all IDF jobs green.

## Note

An `esp32 @ IDF 6.0.2` row was prototyped as well but is left out: the trial build surfaced pre-existing IDF v6 incompatibilities in this library (legacy touch driver deprecation under -Werror, removed `driver/rmt_types.h`, and `i2s_port_t` breakage), which deserve a dedicated migration effort before the CI can gate on IDF 6.