### PR TITLE
Harden the I2S driver lifecycle and modernize chip branching

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -133,6 +133,8 @@ static constexpr const uint8_t _pin_table_i2c_ex_in[][5] = {
 { board_t::board_M5StampC5    , 255        ,255         , 255        ,255         },
 { board_t::board_M5ToughC5    , GPIO_NUM_3 ,GPIO_NUM_2  , GPIO_NUM_3 ,GPIO_NUM_2  }, // PortA は内部バスと同一 (レベルシフタ経由の物理分配)
 { board_t::board_unknown      , 255        ,255         , 255        ,255         },
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
+{ board_t::board_unknown      , 255        ,255         , 255        ,255         },
 #else
 { board_t::board_M5Stack      , GPIO_NUM_22,GPIO_NUM_21 , GPIO_NUM_22,GPIO_NUM_21 },
 { board_t::board_M5Paper      , GPIO_NUM_22,GPIO_NUM_21 , GPIO_NUM_32,GPIO_NUM_25 },
@@ -166,6 +168,7 @@ static constexpr const uint8_t _pin_table_port_bc[][5] = {
 { board_t::board_M5Tab5       , GPIO_NUM_17,GPIO_NUM_52, GPIO_NUM_7 ,GPIO_NUM_6  }, // Tab5
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
 { board_t::board_M5ToughC5    , GPIO_NUM_1 ,GPIO_NUM_6  , GPIO_NUM_12,GPIO_NUM_11 },
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
 #else
 { board_t::board_M5Stack      , GPIO_NUM_36,GPIO_NUM_26 , GPIO_NUM_16,GPIO_NUM_17 },
 { board_t::board_M5StackCore2 , GPIO_NUM_36,GPIO_NUM_26 , GPIO_NUM_13,GPIO_NUM_14 },
@@ -187,6 +190,7 @@ static constexpr const uint8_t _pin_table_port_de[][5] = {
 #elif defined (CONFIG_IDF_TARGET_ESP32C61)
 #elif defined (CONFIG_IDF_TARGET_ESP32H2)
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
 #else
 { board_t::board_M5Stack      , GPIO_NUM_34,GPIO_NUM_35 , GPIO_NUM_5 ,GPIO_NUM_13 },
 { board_t::board_M5StackCore2 , GPIO_NUM_34,GPIO_NUM_35 , GPIO_NUM_27,GPIO_NUM_19 },
@@ -218,6 +222,7 @@ static constexpr const uint8_t _pin_table_sd[][7] = {
 { board_t::board_M5Tab5       , GPIO_NUM_43, GPIO_NUM_44, GPIO_NUM_39, GPIO_NUM_40, GPIO_NUM_41, GPIO_NUM_42 },
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
 { board_t::board_M5ToughC5    , GPIO_NUM_9 , GPIO_NUM_7 , GPIO_NUM_8 , 255        , 255        , GPIO_NUM_10 },
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
 #else
 { board_t::board_M5Stack      , GPIO_NUM_18, GPIO_NUM_23, GPIO_NUM_19, 255        , 255        , GPIO_NUM_4  },
 { board_t::board_M5StackCore2 , GPIO_NUM_18, GPIO_NUM_23, GPIO_NUM_38, 255        , 255        , GPIO_NUM_4  },
@@ -251,6 +256,7 @@ static constexpr const uint8_t _pin_table_other0[][2] = {
 #elif defined (CONFIG_IDF_TARGET_ESP32H2)
 { board_t::board_M5NanoH2     , GPIO_NUM_11 },
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
 #else
 { board_t::board_M5Stack      , GPIO_NUM_15 },
 { board_t::board_M5StackCore2 , GPIO_NUM_25 },
@@ -279,6 +285,7 @@ static constexpr const uint8_t _pin_table_other1[][2] = {
 #elif defined (CONFIG_IDF_TARGET_ESP32C61)
 #elif defined (CONFIG_IDF_TARGET_ESP32H2)
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
 #else
 
 { board_t::board_M5StickCPlus2 , GPIO_NUM_4  },
@@ -383,6 +390,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
 },
 #elif defined (CONFIG_IDF_TARGET_ESP32H2)
 #elif defined (CONFIG_IDF_TARGET_ESP32C5)
+#elif defined (CONFIG_IDF_TARGET_ESP32S2)
 #else
 { board_t::board_M5Stack  ,
   255        , GPIO_NUM_35,

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -25,15 +25,15 @@
 #include <esp_log.h>
 #include <math.h>
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+#include "m5unified_i2s.h"
+
+#if defined (M5UNIFIED_I2S_HW_V2)
  #if __has_include(<driver/i2s_std.h>)
   #if __has_include(<hal/i2s_ll.h>)
    #include <hal/i2s_ll.h>
   #endif
  #endif
 #endif
-
-#include "m5unified_i2s.h"
 
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)  
 #if __has_include (<hal/adc_ll.h>)
@@ -95,20 +95,24 @@ namespace m5
   static i2s_chan_handle_t _i2s_handle[M5UNIFIED_I2S_PORT_COUNT] = { nullptr, };
 
   static esp_err_t _i2s_start(i2s_port_t port) {
+    if (_i2s_handle[port] == nullptr) { return ESP_FAIL; }
     return i2s_channel_enable(_i2s_handle[port]);
   }
   static esp_err_t _i2s_stop(i2s_port_t port)
   {
+    if (_i2s_handle[port] == nullptr) { return ESP_OK; }
     return i2s_channel_disable(_i2s_handle[port]);
   }
   static esp_err_t _i2s_read(i2s_port_t port, void* buf, size_t len, size_t* result, TickType_t tick) {
+    if (_i2s_handle[port] == nullptr) { return ESP_FAIL; }
     return i2s_channel_read(_i2s_handle[port], buf, len, result, tick);
   }
   static esp_err_t _i2s_driver_uninstall(i2s_port_t port)
   {
     if (_i2s_handle[port] != nullptr) {
       auto res = i2s_del_channel(_i2s_handle[port]);
-      _i2s_handle[port] = nullptr;
+      /// Keep the handle when the deletion fails. (e.g. the channel is still running)
+      if (res == ESP_OK) { _i2s_handle[port] = nullptr; }
       return res;
     }
     return ESP_OK;
@@ -306,8 +310,9 @@ namespace m5
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(_cfg.i2s_port, I2S_ROLE_MASTER);
     chan_cfg.dma_desc_num = _cfg.dma_buf_count;
     chan_cfg.dma_frame_num = _cfg.dma_buf_len;
-    _i2s_driver_uninstall(_cfg.i2s_port);
-    esp_err_t err = i2s_new_channel(&chan_cfg, nullptr, &_i2s_handle[_cfg.i2s_port]);
+    esp_err_t err = _i2s_driver_uninstall(_cfg.i2s_port);
+    if (err != ESP_OK) { return err; }
+    err = i2s_new_channel(&chan_cfg, nullptr, &_i2s_handle[_cfg.i2s_port]);
     if (err != ESP_OK) { return err; }
 
 #if SOC_I2S_SUPPORTS_PDM_RX
@@ -360,11 +365,17 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     i2s_config.gpio_cfg.din  = (gpio_num_t)_cfg.pin_data_in;
     err = i2s_channel_init_std_mode(_i2s_handle[_cfg.i2s_port], &i2s_config);
 }
+    if (err != ESP_OK)
+    {
+      _i2s_driver_uninstall(_cfg.i2s_port);
+      return err;
+    }
 
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
     if (_cfg.use_adc)
     {
       err = _i2s_set_adc(_cfg.i2s_port, (gpio_num_t)_cfg.pin_data_in);
+      if (err != ESP_OK) { _i2s_driver_uninstall(_cfg.i2s_port); }
     }
 #endif
 
@@ -431,13 +442,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 
     bool use_pdm = (self->_cfg.pin_bck < 0 && !self->_cfg.use_adc);
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined (CONFIG_IDF_TARGET_ESP32C6) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32S3 )
-    static constexpr uint32_t PLL_D2_CLK = 120*1000*1000; // 240 MHz/2
-#elif defined ( CONFIG_IDF_TARGET_ESP32P4 )
-    static constexpr uint32_t PLL_D2_CLK = 20*1000*1000; // 20 MHz
-#else
-    static constexpr uint32_t PLL_D2_CLK = 80*1000*1000; // 160 MHz/2
-#endif
+    static constexpr uint32_t PLL_D2_CLK = M5UNIFIED_I2S_PLL_D2_HZ;
 
     uint32_t bits = (self->_cfg.use_adc) ? 1 : 16; /// 1サンプリング当たりの出力ビット数;
     uint32_t div_a, div_b, div_n;
@@ -460,7 +465,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 #endif
 #endif
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+#if defined (M5UNIFIED_I2S_HW_V2)
 
     dev->rx_conf.rx_pdm_en = use_pdm;
     dev->rx_conf.rx_tdm_en = !use_pdm;
@@ -471,8 +476,6 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     dev->rx_conf.rx_pdm2pcm_en = use_pdm;
     dev->rx_conf.rx_pdm_sinc_dsr_16_en = 1;
 #endif
-    dev->rx_conf.rx_update = 1;
-
 #if defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
     dev->rx_conf.rx_bck_div_num = div_m - 1;
 #else
@@ -524,12 +527,18 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     dev->rx_clkm_div_conf.rx_clkm_div_yn1 = yn1;
     dev->rx_clkm_conf.rx_clkm_div_num = div_n;
     dev->rx_clkm_conf.rx_clk_sel = 1;   // PLL_240M_CLK
-    dev->tx_clkm_conf.clk_en = 1;
+    dev->tx_clkm_conf.clk_en = 1;       // I2S module common clock gate (physically located in the TX register)
     dev->rx_clkm_conf.rx_clk_active = 1;
-
-    dev->rx_conf.rx_update = 1;
-    dev->rx_conf.rx_update = 0;
 #endif
+
+    // Latch the whole clock/format configuration at once. This is the same
+    // sequence as the HAL's i2s_ll_rx_update (the function itself does not exist
+    // before ESP-IDF v5.5): the hardware self-clears the bit once the update has
+    // been synchronized into the I2S clock domain. The wait is deliberately
+    // unbounded to match the HAL implementation; the module clocks are already
+    // enabled by the driver at this point, so the bit always clears.
+    dev->rx_conf.rx_update = 1;
+    while (dev->rx_conf.rx_update) {} // wait for the hardware to clear the update bit
 
 #else
 

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -542,18 +542,24 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 
 #else
 
+#if !defined (CONFIG_IDF_TARGET_ESP32S2) // ESP32-S2 has no PDM support
     if (use_pdm)
     {
       dev->pdm_conf.rx_sinc_dsr_16_en = 1; // 0=DSR64 / 1=DSR128
       dev->pdm_conf.pdm2pcm_conv_en = 1;
       dev->pdm_conf.rx_pdm_en = 1;
     }
+#endif
 
     dev->sample_rate_conf.rx_bck_div_num = div_m;
     dev->clkm_conf.clkm_div_a = div_a;
     dev->clkm_conf.clkm_div_b = div_b;
     dev->clkm_conf.clkm_div_num = div_n;
+#if defined (CONFIG_IDF_TARGET_ESP32S2)
+    dev->clkm_conf.clk_sel = 2; // PLL_160M ( 1=APLL )
+#else
     dev->clkm_conf.clka_en = 0; // APLL disable : PLL_160M
+#endif
 
     // If RX is not reset here, BCK polarity may be inverted.
     dev->conf.rx_reset = 1;

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -27,15 +27,7 @@
 
 #include "m5unified_i2s.h"
 
-#if defined (M5UNIFIED_I2S_HW_V2)
- #if __has_include(<driver/i2s_std.h>)
-  #if __has_include(<hal/i2s_ll.h>)
-   #include <hal/i2s_ll.h>
-  #endif
- #endif
-#endif
-
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)  
+#if defined (M5UNIFIED_I2S_ADC_DAC)
 #if __has_include (<hal/adc_ll.h>)
  #pragma GCC diagnostic push
  #pragma GCC diagnostic ignored "-Wconversion"
@@ -117,8 +109,7 @@ namespace m5
     }
     return ESP_OK;
   }
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)  
-
+#if defined (M5UNIFIED_I2S_ADC_DAC)
   struct adc_digi_pattern_table_t {
       union {
           struct {
@@ -242,7 +233,7 @@ namespace m5
   {
     return i2s_driver_uninstall(port);
   }
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)  
+#if defined (M5UNIFIED_I2S_ADC_DAC)
   static esp_err_t _i2s_set_adc(i2s_port_t port, gpio_num_t pin_data_in) {
     if (port == I2S_NUM_0)
     { /// レジスタを操作してADCモードの設定を有効にする ;
@@ -371,7 +362,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
       return err;
     }
 
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
     if (_cfg.use_adc)
     {
       err = _i2s_set_adc(_cfg.i2s_port, (gpio_num_t)_cfg.pin_data_in);
@@ -415,7 +406,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     }
     if (err != ESP_OK) { return err; }
 
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
     if (_cfg.use_adc)
     {
       err = _i2s_set_adc(_cfg.i2s_port, (gpio_num_t)_cfg.pin_data_in);
@@ -476,9 +467,9 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     dev->rx_conf.rx_pdm2pcm_en = use_pdm;
     dev->rx_conf.rx_pdm_sinc_dsr_16_en = 1;
 #endif
-#if defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
-    dev->rx_conf.rx_bck_div_num = div_m - 1;
-#else
+#if defined (M5UNIFIED_I2S_USE_LL)
+    i2s_ll_rx_set_bck_div_num(dev, div_m); // (the register location differs per chip; the HAL absorbs it)
+#else // ESP-IDF v4 HW v2 targets (ESP32-S3/C3): the HAL header is not C++-clean, write directly
     dev->rx_conf1.rx_bck_div_num = div_m - 1;
 #endif
 
@@ -503,7 +494,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
       }
     }
 
-#if __has_include(<driver/i2s_std.h>)
+#if defined (M5UNIFIED_I2S_USE_LL)
     i2s_ll_rx_set_raw_clk_div(dev, div_n, div_x, div_y, div_b, yn1);
 #endif
 

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -620,6 +620,10 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
         if (os_remain) { continue; }
         os_remain = oversampling;
 
+// Swap the half-word pair order observed on the classic ESP32 RX FIFO
+// (the RX counterpart of the HW v1/v2 TX packing difference). ESP32-S2 is
+// also HW v1 and might need the same swap, but no S2 device with a mic
+// exists to verify, so only the verified classic ESP32 is handled here.
 #if defined (CONFIG_IDF_TARGET_ESP32)
         auto sv0 = sum_value[1];
         auto sv1 = sum_value[0];

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -27,14 +27,6 @@
 
 #include "m5unified_i2s.h"
 
-#if defined (M5UNIFIED_I2S_HW_V2)
- #if __has_include(<driver/i2s_std.h>)
-  #if __has_include(<hal/i2s_ll.h>)
-   #include <hal/i2s_ll.h>
-  #endif
- #endif
-#endif
-
 #if __has_include (<hal/dac_ll.h>)
 #include <hal/dac_types.h>
 #include <hal/dac_ll.h>
@@ -107,7 +99,7 @@ namespace m5
     }
     return ESP_OK;
   }
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
   static esp_err_t _i2s_set_dac(i2s_port_t port, bool left_en, bool right_en) {
     if (port == I2S_NUM_0)
     { /// DACモードの設定を有効にする(I2S0のみ。I2S1はDAC,ADC非対応) ;
@@ -163,7 +155,7 @@ namespace m5
   {
     return i2s_driver_uninstall(port);
   }
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
   static esp_err_t _i2s_set_dac(i2s_port_t port, bool left_en, bool right_en) {
     if (port == I2S_NUM_0)
     { /// レジスタを操作してDACモードの設定を有効にする(I2S0のみ。I2S1はDAC,ADC非対応) ;
@@ -190,7 +182,7 @@ namespace m5
   {
     if (_cfg.pin_data_out < 0) { return ESP_FAIL; }
 
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
     /// DACが使用できるのはI2Sポート0のみ。;
     if (_cfg.use_dac && _cfg.i2s_port != I2S_NUM_0) { return ESP_FAIL; }
 #endif
@@ -240,7 +232,7 @@ namespace m5
       return err;
     }
 
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
     if (_cfg.use_dac)
     {
       bool left_en = _cfg.stereo || (_cfg.pin_data_out == GPIO_NUM_26);
@@ -289,7 +281,7 @@ namespace m5
     }
     if (err != ESP_OK) { return err; }
 
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
     if (_cfg.use_dac)
     {
       bool right_en = _cfg.stereo || (_cfg.pin_data_out == GPIO_NUM_25);
@@ -422,9 +414,9 @@ namespace m5
       dev->tx_conf.tx_chan_equal = 1;
     }
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
-    dev->tx_conf.tx_bck_div_num = div_m - 1;
-#else
+#if defined (M5UNIFIED_I2S_USE_LL)
+    i2s_ll_tx_set_bck_div_num(dev, div_m); // (the register location differs per chip; the HAL absorbs it)
+#else // ESP-IDF v4 HW v2 targets (ESP32-S3/C3): the HAL header is not C++-clean, write directly
     dev->tx_conf1.tx_bck_div_num = div_m - 1;
 #endif
 
@@ -449,7 +441,7 @@ namespace m5
       }
     }
 
-#if __has_include(<driver/i2s_std.h>)
+#if defined (M5UNIFIED_I2S_USE_LL)
     i2s_ll_tx_set_raw_clk_div(dev, div_n, div_x, div_y, div_b, yn1);
 #endif
 
@@ -578,7 +570,7 @@ namespace m5
 
           if (!retry)
           {
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
             if (self->_cfg.use_dac)
             {
               flg_i2s_started = spk_i2s_stop;
@@ -608,7 +600,7 @@ namespace m5
       {
         if (flg_i2s_started == spk_i2s_stop)
         {
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
           if (self->_cfg.use_dac)
           {
             bool left_en = out_stereo || (self->_cfg.pin_data_out == GPIO_NUM_26);
@@ -957,7 +949,7 @@ label_continue_sample:
     SDL_CloseAudio();
 #else
     _i2s_stop(i2s_port);
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+#if defined (M5UNIFIED_I2S_ADC_DAC)
     if (self->_cfg.use_dac)
     {
       _i2s_set_dac(i2s_port, false, false);

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -25,25 +25,9 @@
 #include <sdkconfig.h>
 #include <esp_log.h>
 
-#if __has_include (<soc/soc_caps.h>)
- #include <soc/soc_caps.h>
-#endif
+#include "m5unified_i2s.h"
 
-/// Identify the I2S peripheral generation.
-/// Prefer the soc_caps capability macro (available on ESP-IDF v5 or later).
-/// On older ESP-IDF (v4.x / Arduino core 2.x) whose soc_caps.h predates
-/// SOC_I2S_HW_VERSION_x, the supported chip set is fixed (ESP32/S2/S3/C3, so the
-/// list below is final): enumerate the HW v1 targets (ESP32/ESP32-S2) and treat
-/// the rest as HW v2.
-#if defined (SOC_I2S_HW_VERSION_2) || defined (SOC_I2S_HW_VERSION_1)
- #if SOC_I2S_HW_VERSION_2
-  #define M5UNIFIED_I2S_HW_V2 1
- #endif
-#elif defined (CONFIG_IDF_TARGET) && !defined (CONFIG_IDF_TARGET_ESP32) && !defined (CONFIG_IDF_TARGET_ESP32S2)
- #define M5UNIFIED_I2S_HW_V2 1
-#endif
-
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+#if defined (M5UNIFIED_I2S_HW_V2)
  #if __has_include(<driver/i2s_std.h>)
   #if __has_include(<hal/i2s_ll.h>)
    #include <hal/i2s_ll.h>
@@ -56,8 +40,6 @@
 #include <hal/dac_ll.h>
 #include <driver/rtc_io.h>
 #endif
-
-#include "m5unified_i2s.h"
 
 #endif
 
@@ -119,12 +101,13 @@ namespace m5
   {
     if (_i2s_handle[port] != nullptr) {
       auto res = i2s_del_channel(_i2s_handle[port]);
-      _i2s_handle[port] = nullptr;
+      /// Keep the handle when the deletion fails. (e.g. the channel is still running)
+      if (res == ESP_OK) { _i2s_handle[port] = nullptr; }
       return res;
     }
     return ESP_OK;
   }
-#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)  
+#if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
   static esp_err_t _i2s_set_dac(i2s_port_t port, bool left_en, bool right_en) {
     if (port == I2S_NUM_0)
     { /// DACモードの設定を有効にする(I2S0のみ。I2S1はDAC,ADC非対応) ;
@@ -217,8 +200,9 @@ namespace m5
     chan_cfg.dma_desc_num = _cfg.dma_buf_count;
     chan_cfg.dma_frame_num = _cfg.dma_buf_len;
     chan_cfg.auto_clear = true;
-    _i2s_driver_uninstall(_cfg.i2s_port);
-    esp_err_t err = i2s_new_channel(&chan_cfg, &_i2s_handle[_cfg.i2s_port], nullptr);
+    esp_err_t err = _i2s_driver_uninstall(_cfg.i2s_port);
+    if (err != ESP_OK) { return err; }
+    err = i2s_new_channel(&chan_cfg, &_i2s_handle[_cfg.i2s_port], nullptr);
     if (err != ESP_OK) { return err; }
 
     i2s_std_config_t i2s_config;
@@ -250,6 +234,11 @@ namespace m5
     i2s_config.gpio_cfg.mclk = (gpio_num_t)_cfg.pin_mck;
     i2s_config.gpio_cfg.din  = (gpio_num_t)I2S_PIN_NO_CHANGE;
     err = i2s_channel_init_std_mode(_i2s_handle[_cfg.i2s_port], &i2s_config);
+    if (err != ESP_OK)
+    {
+      _i2s_driver_uninstall(_cfg.i2s_port);
+      return err;
+    }
 
 #if !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
     if (_cfg.use_dac)
@@ -257,6 +246,7 @@ namespace m5
       bool left_en = _cfg.stereo || (_cfg.pin_data_out == GPIO_NUM_26);
       bool right_en = _cfg.stereo || (_cfg.pin_data_out == GPIO_NUM_25);
       err = _i2s_set_dac(_cfg.i2s_port, left_en, right_en);
+      if (err != ESP_OK) { _i2s_driver_uninstall(_cfg.i2s_port); }
     }
 #endif
 
@@ -398,13 +388,7 @@ namespace m5
 #else
     const i2s_port_t i2s_port = self->_cfg.i2s_port;
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined (CONFIG_IDF_TARGET_ESP32C6) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined (CONFIG_IDF_TARGET_ESP32C61) || defined ( CONFIG_IDF_TARGET_ESP32S3 )
-    static constexpr uint32_t PLL_D2_CLK = 120*1000*1000; // 240 MHz/2
-#elif defined ( CONFIG_IDF_TARGET_ESP32P4 )
-    static constexpr uint32_t PLL_D2_CLK = 20*1000*1000; // 20 MHz
-#else
-    static constexpr uint32_t PLL_D2_CLK = 80*1000*1000; // 160 MHz/2
-#endif
+    static constexpr uint32_t PLL_D2_CLK = M5UNIFIED_I2S_PLL_D2_HZ;
     uint32_t bits = (self->_cfg.use_dac) ? 1 : 16; /// 1サンプリング当たりの出力ビット数;
     uint32_t div_a, div_b, div_n;
     uint32_t div_m = 32 / bits; /// MCLKを使用しない場合、サンプリングレート誤差が少なくなるようにdiv_mを調整する;
@@ -430,7 +414,7 @@ namespace m5
 #endif
 #endif
 
-#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined (CONFIG_IDF_TARGET_ESP32C6) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+#if defined (M5UNIFIED_I2S_HW_V2)
     // モノラル設定時、同じデータを左右両方に送信する設定
     if (!self->_cfg.stereo && !self->_cfg.use_dac && !self->_cfg.buzzer)
     {
@@ -489,12 +473,18 @@ namespace m5
     dev->tx_clkm_div_conf.tx_clkm_div_yn1 = yn1;
     dev->tx_clkm_conf.tx_clkm_div_num = div_n;
     dev->tx_clkm_conf.tx_clk_sel = 1;   // PLL_240M_CLK
-    dev->tx_clkm_conf.clk_en = 1;
+    dev->tx_clkm_conf.clk_en = 1;       // I2S module common clock gate (physically located in the TX register)
     dev->tx_clkm_conf.tx_clk_active = 1;
-
-    dev->tx_conf.tx_update = 1;
-    dev->tx_conf.tx_update = 0;
 #endif
+
+    // Latch the whole clock/format configuration at once. This is the same
+    // sequence as the HAL's i2s_ll_tx_update (the function itself does not exist
+    // before ESP-IDF v5.5): the hardware self-clears the bit once the update has
+    // been synchronized into the I2S clock domain. The wait is deliberately
+    // unbounded to match the HAL implementation; the module clocks are already
+    // enabled by the driver at this point, so the bit always clears.
+    dev->tx_conf.tx_update = 1;
+    while (dev->tx_conf.tx_update) {} // wait for the hardware to clear the update bit
 
 #else
 

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -492,7 +492,11 @@ namespace m5
     dev->clkm_conf.clkm_div_a = div_a;
     dev->clkm_conf.clkm_div_b = div_b;
     dev->clkm_conf.clkm_div_num = div_n;
+#if defined (CONFIG_IDF_TARGET_ESP32S2)
+    dev->clkm_conf.clk_sel = 2; // PLL_160M ( 1=APLL )
+#else
     dev->clkm_conf.clka_en = 0; // APLL disable : PLL_160M
+#endif
 
     // If TX is not reset here, BCK polarity may be inverted.
     dev->conf.tx_reset = 1;

--- a/src/utility/m5unified_i2s.h
+++ b/src/utility/m5unified_i2s.h
@@ -29,3 +29,23 @@
  /// (Targets without I2S may include this header freely; they never reach here.)
  #error "Cannot determine the number of I2S ports for this target"
 #endif
+
+/// I2S register layout generation. Prefer the SoC capability macro; fall back to a
+/// target list for cores whose soc_caps.h predates SOC_I2S_HW_VERSION_x (e.g. ESP-IDF v4).
+#if defined (SOC_I2S_HW_VERSION_2) || defined (SOC_I2S_HW_VERSION_1)
+ #if SOC_I2S_HW_VERSION_2
+  #define M5UNIFIED_I2S_HW_V2 1
+ #endif
+#elif defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+ #define M5UNIFIED_I2S_HW_V2 1
+#endif
+
+/// Source clock frequency assumed by the raw clock divider setup in the speaker/mic tasks.
+/// (per-chip PLL selection; this cannot be derived from a capability macro)
+#if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 )
+ #define M5UNIFIED_I2S_PLL_D2_HZ (120*1000*1000) // 240 MHz/2
+#elif defined ( CONFIG_IDF_TARGET_ESP32P4 )
+ #define M5UNIFIED_I2S_PLL_D2_HZ (20*1000*1000)  // 20 MHz
+#else
+ #define M5UNIFIED_I2S_PLL_D2_HZ (80*1000*1000)  // 160 MHz/2
+#endif

--- a/src/utility/m5unified_i2s.h
+++ b/src/utility/m5unified_i2s.h
@@ -41,13 +41,17 @@
  #define M5UNIFIED_I2S_ADC_DAC 1
 #endif
 
-/// I2S register layout generation. Prefer the SoC capability macro; fall back to a
-/// target list for cores whose soc_caps.h predates SOC_I2S_HW_VERSION_x (e.g. ESP-IDF v4).
+/// I2S register layout generation. Prefer the SoC capability macro (ESP-IDF v5+).
+/// On older ESP-IDF (v4.x / Arduino core 2.x) whose soc_caps.h predates
+/// SOC_I2S_HW_VERSION_x, the supported chip set is fixed: enumerate the HW v1
+/// targets (ESP32/ESP32-S2, plus targetless ancient cores = classic ESP32) and
+/// treat everything else as HW v2, since no future SoC will revert to the v1
+/// peripheral.
 #if defined (SOC_I2S_HW_VERSION_2) || defined (SOC_I2S_HW_VERSION_1)
  #if SOC_I2S_HW_VERSION_2
   #define M5UNIFIED_I2S_HW_V2 1
  #endif
-#elif defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
+#elif defined (CONFIG_IDF_TARGET) && !defined (CONFIG_IDF_TARGET_ESP32) && !defined (CONFIG_IDF_TARGET_ESP32S2)
  #define M5UNIFIED_I2S_HW_V2 1
 #endif
 

--- a/src/utility/m5unified_i2s.h
+++ b/src/utility/m5unified_i2s.h
@@ -43,10 +43,9 @@
 
 /// I2S register layout generation. Prefer the SoC capability macro (ESP-IDF v5+).
 /// On older ESP-IDF (v4.x / Arduino core 2.x) whose soc_caps.h predates
-/// SOC_I2S_HW_VERSION_x, the supported chip set is fixed: enumerate the HW v1
-/// targets (ESP32/ESP32-S2, plus targetless ancient cores = classic ESP32) and
-/// treat everything else as HW v2, since no future SoC will revert to the v1
-/// peripheral.
+/// SOC_I2S_HW_VERSION_x, the supported chip set is fixed (ESP32/S2/S3/C3, so the
+/// list below is final): enumerate the HW v1 targets (ESP32/ESP32-S2, plus
+/// targetless ancient cores = classic ESP32) and treat the rest as HW v2.
 #if defined (SOC_I2S_HW_VERSION_2) || defined (SOC_I2S_HW_VERSION_1)
  #if SOC_I2S_HW_VERSION_2
   #define M5UNIFIED_I2S_HW_V2 1
@@ -63,12 +62,22 @@
  #define M5UNIFIED_I2S_USE_LL 1
 #endif
 
-/// Source clock frequency assumed by the raw clock divider setup in the speaker/mic tasks.
-/// (per-chip PLL selection; this cannot be derived from a capability macro)
+/// Source clock frequency assumed by the raw clock divider setup in the speaker/mic
+/// tasks (the frequency selected by tx/rx_clk_sel = 1 on HW v2, PLL_160M on HW v1).
+/// This is a per-chip physical property that cannot be derived from a capability
+/// macro, so every known target is enumerated explicitly.
 #if defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 )
  #define M5UNIFIED_I2S_PLL_D2_HZ (120*1000*1000) // 240 MHz/2
 #elif defined ( CONFIG_IDF_TARGET_ESP32P4 )
  #define M5UNIFIED_I2S_PLL_D2_HZ (20*1000*1000)  // 20 MHz
+#elif defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32H4 )
+ #define M5UNIFIED_I2S_PLL_D2_HZ (96*1000*1000)  // PLL_F96M
 #else
+ /// Unknown I2S-capable targets fall back to the HW v1 value. The message below is
+ /// intentionally not #warning (which fails -Werror builds); it flags that the
+ /// frequency must be verified and added to the table above.
+ #if defined (M5UNIFIED_I2S_PORT_COUNT) && defined (CONFIG_IDF_TARGET) && !defined (CONFIG_IDF_TARGET_ESP32) && !defined (CONFIG_IDF_TARGET_ESP32S2)
+  #pragma message ("M5Unified: unknown target, assuming a 80 MHz I2S source clock. Verify it and extend the table in m5unified_i2s.h")
+ #endif
  #define M5UNIFIED_I2S_PLL_D2_HZ (80*1000*1000)  // 160 MHz/2
 #endif

--- a/src/utility/m5unified_i2s.h
+++ b/src/utility/m5unified_i2s.h
@@ -30,6 +30,17 @@
  #error "Cannot determine the number of I2S ports for this target"
 #endif
 
+/// I2S built-in ADC/DAC capability (classic ESP32 only).
+/// SOC_I2S_SUPPORTS_DAC was removed in ESP-IDF v6 (the HAL provides I2S_LL_ADC_DAC_CAPABLE
+/// instead). Ancient cores may lack soc_caps.h entirely; the classic ESP32 is then
+/// identified by being targetless or by CONFIG_IDF_TARGET_ESP32 (e.g. Arduino core 1.x
+/// defines the target macro but has none of the capability macros).
+/// (capability macros are tested for value as well: a defined-but-zero macro must not
+/// enable the path)
+#if (defined (SOC_I2S_SUPPORTS_DAC) && SOC_I2S_SUPPORTS_DAC) || (defined (I2S_LL_ADC_DAC_CAPABLE) && I2S_LL_ADC_DAC_CAPABLE) || !defined (CONFIG_IDF_TARGET) || defined (CONFIG_IDF_TARGET_ESP32)
+ #define M5UNIFIED_I2S_ADC_DAC 1
+#endif
+
 /// I2S register layout generation. Prefer the SoC capability macro; fall back to a
 /// target list for cores whose soc_caps.h predates SOC_I2S_HW_VERSION_x (e.g. ESP-IDF v4).
 #if defined (SOC_I2S_HW_VERSION_2) || defined (SOC_I2S_HW_VERSION_1)
@@ -38,6 +49,14 @@
  #endif
 #elif defined ( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C6 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 ) || defined ( CONFIG_IDF_TARGET_ESP32C61 ) || defined ( CONFIG_IDF_TARGET_ESP32H2 ) || defined ( CONFIG_IDF_TARGET_ESP32S3 ) || defined ( CONFIG_IDF_TARGET_ESP32P4 )
  #define M5UNIFIED_I2S_HW_V2 1
+#endif
+
+/// The HW v2 raw register setup uses the HAL LL helpers where the header is
+/// available (ESP-IDF v5+). ESP-IDF v4 has no C++-includable i2s_ll.h and writes
+/// the registers directly. The include and every use site share this condition.
+#if defined (M5UNIFIED_I2S_HW_V2) && __has_include (<driver/i2s_std.h>) && __has_include (<hal/i2s_ll.h>)
+ #include <hal/i2s_ll.h>
+ #define M5UNIFIED_I2S_USE_LL 1
 #endif
 
 /// Source clock frequency assumed by the raw clock divider setup in the speaker/mic tasks.


### PR DESCRIPTION
## Overview
A hardening pass over the I2S speaker/mic driver layer, plus modernization of the chip-specific branching. No behavior change is intended for currently working configurations: the fixes target error paths, latent lifecycle bugs, and future-proofing against new SoCs.

## Changes
**Harden the I2S channel lifecycle**
- Keep the channel handle when `i2s_del_channel` fails (e.g. channel still running) instead of leaking a live channel, and check the uninstall result before creating a new one
- Clean up on init failures instead of reporting false success (std/pdm init, classic DAC/ADC paths)
- Add the missing null-handle guards to the mic path (the speaker path already had them)
- Latch the HW v2 register update once after the whole clock/format configuration, following the documented self-clearing update-bit sequence

**Fix the broken ESP32-S2 build** — S2 (I2S HW v1, but with register-layout differences from the classic ESP32) now compiles; PDM paths are excluded since S2 has no PDM support. Compile-only support: no S2 device with a speaker/mic exists.

**Replace target-series branches with peripheral capability detection**
- The ADC/DAC guards (13 sites) now use a capability chain (`SOC_I2S_SUPPORTS_DAC` / `I2S_LL_ADC_DAC_CAPABLE` / classic-ESP32 fallback covering cores that predate soc_caps.h)
- The I2S HW generation is detected via `SOC_I2S_HW_VERSION_x`; the sample-order fix from #308 now takes the macro from the shared header instead of a local definition

**Invert the ESP-IDF v4 fallback for HW generation detection** — enumerate the HW v1 targets (a set that can no longer grow) instead of the open-ended v2 list, so a future SoC cannot silently fall back to the v1 path

**Enumerate all known I2S source clocks and flag unknown targets** — fixes ESP32-H2 being silently assigned 80 MHz (its I2S source clock is PLL_F96M, a 20% divider error), adds H4, and emits a `#pragma message` for unknown I2S-capable targets

## Verification
- Build matrix green: ESP-IDF v6.0.2 / v5.x and Arduino core 2.x / 3.x across the supported targets, including ESP32-S2 which previously failed to build
- Arduino core 1.x compatibility verified by preprocessing the compatibility header against the official 1.0.6 SDK headers (port count, HW generation, PLL frequency and ADC/DAC capability all resolve to the classic-ESP32 values)
- Real hardware: the speaker/mic paths on this branch were exercised extensively on M5Stack Core (FIRE), Core2, CoreS3SE, StackChan, StickS3 and StopWatch during the #303 investigation
