### PR TITLE
Fix audio defects: P4 clock configuration, ES8388 power-down, divider range, mic RX timing

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -750,19 +750,23 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       2,   49, 0x21,
       0
     };
-    static constexpr const uint8_t disabled_bulk_data[] = {
-      2,    8, 0x00, //set I2S slave mode
-      0
-    };
-    in_i2c_bulk_write(es8388_i2c_addr, enabled ? enabled_bulk_data : disabled_bulk_data);
-
     if (enabled)
-    { // AMP on
+    {
+      in_i2c_bulk_write(es8388_i2c_addr, enabled_bulk_data);
+      // AMP on
       M5.In_I2C.bitOn(pi4io1_i2c_addr, 0x05, 0b00000010, 400000);
     }
     else
-    { // AMP off
-      M5.In_I2C.bitOff(pi4io1_i2c_addr, 0x05, 0b00000010, 400000);
+    { // 正規の power-down シーケンス。end() は cb(false) を I2S 停止より先に呼ぶため、
+      // ここは MCLK/BCLK が生きているうちに実行される。旧実装 (reg8 のみ書き込み) では
+      // DAC 稼働状態のままクロックが絶たれ、次回 enable の reset が毎回異なる残留状態
+      // から行われて受信位相が begin ごとに不定になっていた。毎回同一の power-down
+      // 状態へ落としてから終了することで、次回 enable を常に定義済み状態から始める。
+      M5.In_I2C.bitOff(pi4io1_i2c_addr, 0x05, 0b00000010, 400000); // AMP off (過渡音を出さない)
+      M5.In_I2C.writeRegister8(es8388_i2c_addr, 25, 0x24, 400000); // DACCONTROL3: mute (SoftRamp 維持)
+      M5.delay(1);                                                 // soft-ramp 遷移待ち
+      M5.In_I2C.writeRegister8(es8388_i2c_addr,  4, 0xC0, 400000); // DACPOWER: DAC L/R down + 全出力 off
+      M5.In_I2C.writeRegister8(es8388_i2c_addr,  2, 0xFF, 400000); // CHIPPOWER: 全停止 (ADF deinit と同一の終端状態)
     }
 #endif
     return true;

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -334,8 +334,26 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 #else
     i2s_config.clk_cfg.clk_src = i2s_clock_src_t::I2S_CLK_SRC_PLL_160M;
 #endif
+#if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+    { // ESP32-P4 はクロックをドライバ管理で最終値に確定させる (mic_task での raw 分周
+      // 上書きを行わない)。クロック源既定 (minimum supported revision < 3 のビルドは
+      // XTAL 40MHz / rev >= 3 ビルドは PLL_F160M) もドライバに委ねる。
+      int os = _cfg.over_sampling;
+      if (os < 1) { os = 1; } else if (os > 8) { os = 8; }
+      i2s_config.clk_cfg.sample_rate_hz = _cfg.sample_rate * os;
+      i2s_config.clk_cfg.mclk_multiple = i2s_mclk_multiple_t::I2S_MCLK_MULTIPLE_256;
+#if defined (I2S_LL_DEFAULT_CLK_FREQ)
+      // ドライバは source >= 2x MCLK を要求するため、40MHz source ビルドでは 256fs は
+      // 約 78kHz が上限。それを超えるレートは 128fs に落として初期化可能にする。
+      if ((uint64_t)i2s_config.clk_cfg.sample_rate_hz * 512 > I2S_LL_DEFAULT_CLK_FREQ) {
+        i2s_config.clk_cfg.mclk_multiple = i2s_mclk_multiple_t::I2S_MCLK_MULTIPLE_128;
+      }
+#endif
+    }
+#else
     i2s_config.clk_cfg.sample_rate_hz = 48000; // dummy setting
     i2s_config.clk_cfg.mclk_multiple = i2s_mclk_multiple_t::I2S_MCLK_MULTIPLE_128; // dummy setting
+#endif
     i2s_config.slot_cfg.data_bit_width = i2s_data_bit_width_t::I2S_DATA_BIT_WIDTH_16BIT;
     i2s_config.slot_cfg.slot_bit_width = i2s_slot_bit_width_t::I2S_SLOT_BIT_WIDTH_16BIT;
     i2s_config.slot_cfg.slot_mode = (_cfg.stereo) ? i2s_slot_mode_t::I2S_SLOT_MODE_STEREO :  i2s_slot_mode_t::I2S_SLOT_MODE_MONO;
@@ -433,6 +451,14 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
 
     bool use_pdm = (self->_cfg.pin_bck < 0 && !self->_cfg.use_adc);
 
+#if defined (CONFIG_IDF_TARGET_ESP32P4)
+    // ESP32-P4 の std 経路はクロックを _setup_i2s でドライバ管理により最終値に
+    // 設定済みのため、raw 分周の上書きを行わない (PDM 経路は従来どおり)。
+    const bool skip_raw_clk = !use_pdm;
+#else
+    const bool skip_raw_clk = false;
+#endif
+
     static constexpr uint32_t PLL_D2_CLK = M5UNIFIED_I2S_PLL_D2_HZ;
 
     uint32_t bits = (self->_cfg.use_adc) ? 1 : 16; /// 1サンプリング当たりの出力ビット数;
@@ -467,6 +493,8 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     dev->rx_conf.rx_pdm2pcm_en = use_pdm;
     dev->rx_conf.rx_pdm_sinc_dsr_16_en = 1;
 #endif
+    if (!skip_raw_clk) {
+
 #if defined (M5UNIFIED_I2S_USE_LL)
     i2s_ll_rx_set_bck_div_num(dev, div_m); // (the register location differs per chip; the HAL absorbs it)
 #else // ESP-IDF v4 HW v2 targets (ESP32-S3/C3): the HAL header is not C++-clean, write directly
@@ -521,6 +549,8 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     dev->tx_clkm_conf.clk_en = 1;       // I2S module common clock gate (physically located in the TX register)
     dev->rx_clkm_conf.rx_clk_active = 1;
 #endif
+
+    } // !skip_raw_clk
 
     // Latch the whole clock/format configuration at once. This is the same
     // sequence as the HAL's i2s_ll_rx_update (the function itself does not exist

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -95,9 +95,10 @@ namespace m5
     if (_i2s_handle[port] == nullptr) { return ESP_OK; }
     return i2s_channel_disable(_i2s_handle[port]);
   }
-  static esp_err_t _i2s_read(i2s_port_t port, void* buf, size_t len, size_t* result, TickType_t tick) {
+  static esp_err_t _i2s_read(i2s_port_t port, void* buf, size_t len, size_t* result, uint32_t timeout_ms) {
     if (_i2s_handle[port] == nullptr) { return ESP_FAIL; }
-    return i2s_channel_read(_i2s_handle[port], buf, len, result, tick);
+    /// i2s_channel_read のタイムアウトはミリ秒 (旧 i2s_read の tick 数とは契約が異なる)
+    return i2s_channel_read(_i2s_handle[port], buf, len, result, timeout_ms);
   }
   static esp_err_t _i2s_driver_uninstall(i2s_port_t port)
   {
@@ -225,9 +226,9 @@ namespace m5
   {
     return i2s_stop(port);
   }
-  static esp_err_t _i2s_read(i2s_port_t port, void* buf, size_t len, size_t* result, TickType_t tick)
+  static esp_err_t _i2s_read(i2s_port_t port, void* buf, size_t len, size_t* result, uint32_t timeout_ms)
   {
-    return i2s_read(port, buf, len, result, tick);
+    return i2s_read(port, buf, len, result, pdMS_TO_TICKS(timeout_ms));
   }
   static esp_err_t _i2s_driver_uninstall(i2s_port_t port)
   {
@@ -601,11 +602,18 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     const bool in_stereo = self->_cfg.stereo;
     int32_t os_remain = oversampling;
     const size_t dma_buf_len = self->_cfg.dma_buf_len;
-    int16_t* src_buf = (int16_t*)alloca(dma_buf_len * sizeof(int16_t));
-    memset(src_buf, 0, dma_buf_len * sizeof(int16_t));
+    /// dma_buf_len は DMA descriptor のフレーム数として使われる (_setup_i2s の
+    /// dma_frame_num)。読み出しは descriptor 境界に整列する処理チャンク
+    /// (stereo 16bit なら 1 枚分、mono/PDM なら 2 枚分) を単位に行う。
+    /// これより小さい単位で読むと、IDF の i2s_channel_read はキュー逼迫時に
+    /// descriptor の未読部分を破棄するため、サンプル欠落による位相誤差
+    /// (可聴ノイズ) が生じる。
+    const size_t read_bytes = dma_buf_len * 2 * sizeof(int16_t);
+    int16_t* src_buf = (int16_t*)alloca(read_bytes);
+    memset(src_buf, 0, read_bytes);
 
-    _i2s_read(self->_cfg.i2s_port, src_buf, dma_buf_len, &src_len, portTICK_PERIOD_MS);
-    _i2s_read(self->_cfg.i2s_port, src_buf, dma_buf_len, &src_len, portTICK_PERIOD_MS);
+    _i2s_read(self->_cfg.i2s_port, src_buf, read_bytes, &src_len, 10);
+    _i2s_read(self->_cfg.i2s_port, src_buf, read_bytes, &src_len, 10);
 
     while (self->_task_running)
     {
@@ -628,6 +636,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
           src_len = 0;
           sum_value[0] = 0;
           sum_value[1] = 0;
+          os_remain = oversampling;
           continue;
         }
       }
@@ -635,7 +644,19 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
       {
         if (src_idx >= src_len)
         {
-          _i2s_read(self->_cfg.i2s_port, src_buf, dma_buf_len, &src_len, 100 / portTICK_PERIOD_MS);
+          /// 有効なデータが得られるまで再試行する。ここで空のまま下の do-while に
+          /// 落ちると、直前バッファの先頭フレームを 1 枚余分に消費してしまい
+          /// (do は条件確認前に必ず 1 回実行される)、時間軸が入力 1 フレーム分
+          /// ずれて可聴の位相ノイズになる。
+          for (;;)
+          {
+            src_len = 0;
+            if (!self->_task_running) { break; }
+            if (ESP_OK == _i2s_read(self->_cfg.i2s_port, src_buf, read_bytes, &src_len, 100)
+             && src_len != 0 && 0 == (src_len & 3))
+            { break; }
+          }
+          if (src_len == 0) { break; } /// タスク終了要求時のみ (消費ループを抜ける)
           src_len >>= 1;
           src_idx = 0;
         }
@@ -798,7 +819,7 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     res = (ESP_OK == _setup_i2s()) && res;
     if (res)
     {
-      size_t stack_size = 2048 + (_cfg.dma_buf_len * sizeof(uint16_t));
+      size_t stack_size = 2048 + (_cfg.dma_buf_len * sizeof(uint32_t));
       _task_running = true;
 #if portNUM_PROCESSORS > 1
       if (_cfg.task_pinned_core < portNUM_PROCESSORS)

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -412,6 +412,17 @@ namespace m5
       div_m = 8;
     }
 
+    { /// 低サンプリングレートで分周値が n の上限 255 を超える場合、BCK 分周 (div_m) を
+      /// 引き上げてレンジ内に収める。これを行わないと n が飽和して実レートが大きく
+      /// ずれ (例: S3 の 12000Hz 指定で実 14649Hz)、リサンプラの補間歪みが生じる。
+      const uint64_t limit = 255ULL * bits * self->_cfg.sample_rate;
+      if (limit) {
+        uint32_t min_m = (uint32_t)((PLL_D2_CLK + limit - 1) / limit);
+        if (div_m < min_m) {
+          div_m = (min_m < 63) ? min_m : 63; // BCK 分周レジスタの上限 (6bit) でクランプ
+        }
+      }
+    }
 
     calcClockDiv(&div_a, &div_b, &div_n, PLL_D2_CLK, div_m * bits * self->_cfg.sample_rate);
 

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -204,8 +204,25 @@ namespace m5
 #else
     i2s_config.clk_cfg.clk_src = i2s_clock_src_t::I2S_CLK_SRC_PLL_160M;
 #endif
+#if defined ( CONFIG_IDF_TARGET_ESP32P4 )
+    // ESP32-P4 はクロックをドライバ管理で最終値に確定させる (spk_task での raw 分周
+    // 上書きを行わない)。ここで実レートを渡すことで、begin 中のクロック遷移が
+    // 一度きりになり、外付け codec (Tab5=ES8388) のロック失敗を防ぐ。
+    // クロック源既定 (minimum supported revision < 3 のビルドは XTAL 40MHz /
+    // rev >= 3 ビルドは PLL_F160M) もドライバに委ねる。
+    i2s_config.clk_cfg.sample_rate_hz = _cfg.sample_rate;
+    i2s_config.clk_cfg.mclk_multiple = i2s_mclk_multiple_t::I2S_MCLK_MULTIPLE_256;
+#if defined (I2S_LL_DEFAULT_CLK_FREQ)
+    // ドライバは source >= 2x MCLK を要求するため、40MHz source ビルドでは 256fs は
+    // 約 78kHz が上限。それを超えるレートは 128fs に落として初期化可能にする。
+    if ((uint64_t)_cfg.sample_rate * 512 > I2S_LL_DEFAULT_CLK_FREQ) {
+      i2s_config.clk_cfg.mclk_multiple = i2s_mclk_multiple_t::I2S_MCLK_MULTIPLE_128;
+    }
+#endif
+#else
     i2s_config.clk_cfg.sample_rate_hz = 48000; // dummy setting
     i2s_config.clk_cfg.mclk_multiple = i2s_mclk_multiple_t::I2S_MCLK_MULTIPLE_128; // dummy setting
+#endif
     i2s_config.slot_cfg.data_bit_width = i2s_data_bit_width_t::I2S_DATA_BIT_WIDTH_16BIT;
     i2s_config.slot_cfg.slot_bit_width = i2s_slot_bit_width_t::I2S_SLOT_BIT_WIDTH_16BIT;
     i2s_config.slot_cfg.slot_mode = (_cfg.stereo || _cfg.buzzer) ? i2s_slot_mode_t::I2S_SLOT_MODE_STEREO :  i2s_slot_mode_t::I2S_SLOT_MODE_MONO;
@@ -380,6 +397,12 @@ namespace m5
 #else
     const i2s_port_t i2s_port = self->_cfg.i2s_port;
 
+#if defined (CONFIG_IDF_TARGET_ESP32P4)
+    // クロックは _setup_i2s でドライバ管理により最終値に設定済み (実レート +
+    // 256fs、40MHz source ビルドの高レートのみ 128fs)。
+    // ドライバの分数分周 (a/b ≤ 511) は十分高精度のため、レート換算は公称値でよい。
+    const int32_t spk_sample_rate_x256 = self->_cfg.sample_rate * SAMPLERATE_MUL;
+#else
     static constexpr uint32_t PLL_D2_CLK = M5UNIFIED_I2S_PLL_D2_HZ;
     uint32_t bits = (self->_cfg.use_dac) ? 1 : 16; /// 1サンプリング当たりの出力ビット数;
     uint32_t div_a, div_b, div_n;
@@ -388,6 +411,7 @@ namespace m5
     if ((uint_fast16_t)self->_cfg.pin_mck < GPIO_NUM_MAX) {
       div_m = 8;
     }
+
 
     calcClockDiv(&div_a, &div_b, &div_n, PLL_D2_CLK, div_m * bits * self->_cfg.sample_rate);
 
@@ -497,6 +521,7 @@ namespace m5
     dev->conf.tx_fifo_reset = 0;
 
 #endif
+#endif // !CONFIG_IDF_TARGET_ESP32P4 (raw クロック設定ブロック全体)
     // i2s_zero_dma_buffer(i2s_port);
 
     enum spk_i2s_state

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -419,7 +419,9 @@ namespace m5
       if (limit) {
         uint32_t min_m = (uint32_t)((PLL_D2_CLK + limit - 1) / limit);
         if (div_m < min_m) {
-          div_m = (min_m < 63) ? min_m : 63; // BCK 分周レジスタの上限 (6bit) でクランプ
+          /// 63 は HW v1 (6bit フィールドに生値格納、最大 63) と HW v2 (divisor-1 を
+          /// 格納、単独なら 64 まで表現可) の両 raw レジスタ経路で安全な共通上限。
+          div_m = (min_m < 63) ? min_m : 63;
         }
       }
     }


### PR DESCRIPTION
## Summary
This PR fixes four audio defects found while investigating noise reports on Tab5 and CoreS3.

1. **ESP32-P4: configure the I2S clock via the driver instead of raw registers** — the raw divider path assumed a 20 MHz source clock without ever selecting that source, while the driver default is XTAL 40 MHz in builds targeting a minimum P4 revision below 3, and PLL_F160M in rev-3+ builds; the latter would make the physical rate 8x the calculation. The Speaker/Mic std paths now configure the actual effective rate with `I2S_MCLK_MULTIPLE_256` under driver control, falling back to 128fs when a 40 MHz source cannot satisfy the driver's 2x-MCLK constraint (effective I2S rate above ~78 kHz). This also removes the mid-initialization clock transitions of the raw path.

2. **Tab5: power down the ES8388 properly when the speaker is disabled** — the disable path cut the I2S clocks while the DAC remained active, so subsequent enables intermittently reset the codec from an inconsistent residual state (typically failing within a few re-initializations), producing loud random pops and/or fs/2-image-like noise. An internal I2S loopback capture ruled out the transmitted stream for the pop-noise mode. With the datasheet / esp-adf power-down sequence, 50 consecutive re-initializations played clean and neither noise mode reappeared.

3. **Speaker: keep low sample rates within the clock divider range** — requesting 12000 Hz on ESP32-S3 needs n = 312 (> 255 max), so the divider saturated at a real rate of ~14649 Hz and the software resampler corrected the pitch at the cost of audible interpolation distortion. The BCK divider is now raised minimally to bring n back into range.

4. **Mic: fix stale-frame insertion and I2S read timeout units** — the IDF 5+ read wrapper passed a FreeRTOS tick count to `i2s_channel_read`, which expects milliseconds, reducing the intended 100 ms timeout to a single 0-10 ms tick that races the 8.2 ms DMA descriptor period. The empty-read fallthrough then inserted one stale input frame; with the default 2x oversampling this shifted the output time base by half a sample. Demodulated phase noise at a 2 kHz tone drops from 0.25-0.34 rad rms to 0.007 rad rms, identical to a raw `i2s_channel_read` capture. This affects the IDF 5+ new-channel I2S path on every target.

## Verification
- Tab5 (ESP32-P4, ESP-IDF 6.0.2): all rates from 12000 to 96000 play clean; 50 consecutive speaker re-initializations clean; mic capture verified by FFT/demodulation analysis and by ear.
- CoreS3SE (ESP32-S3, ESP-IDF 6.0.2): all rates including 12000 Hz play clean.
- Local build matrix green for ESP32 / S2 / S3 / C3 / C5 / C6 / C61 / H2 / P4 (ESP-IDF 6.0.2); branch CI (Arduino + ESP-IDF builds) green.
