### PR TITLE
RTC: validate register contents before reporting a date/time

### DIFF
--- a/src/utility/rtc/PCF8563_Class.cpp
+++ b/src/utility/rtc/PCF8563_Class.cpp
@@ -47,22 +47,49 @@ namespace m5
       return false;
     }
 
+    // Decode into locals and validate before committing, so that a corrupted
+    // register value (I2C glitch, uninitialized RTC) results in false instead
+    // of a bogus date such as 45:00:80 or year 2165.
     int idx = 0;
+    rtc_time_t t;
     if (time)
     {
-      time->seconds = bcd2ToByte(buf[idx++] & 0x7f);
-      time->minutes = bcd2ToByte(buf[idx++] & 0x7f);
-      time->hours   = bcd2ToByte(buf[idx++] & 0x3f);
+      std::uint8_t sec  = buf[idx++] & 0x7f;
+      std::uint8_t min  = buf[idx++] & 0x7f;
+      std::uint8_t hour = buf[idx++] & 0x3f;
+      if (!isValidBcd(sec) || !isValidBcd(min) || !isValidBcd(hour))
+      {
+        return false;
+      }
+      t.seconds = bcd2ToByte(sec);
+      t.minutes = bcd2ToByte(min);
+      t.hours   = bcd2ToByte(hour);
     }
 
+    rtc_date_t d;
     if (date)
     {
-      date->date    = bcd2ToByte(buf[idx++] & 0x3f);
-      date->weekDay = bcd2ToByte(buf[idx++] & 0x07);
-      date->month   = bcd2ToByte(buf[idx++] & 0x1f);
-      date->year    = bcd2ToByte(buf[idx] & 0xff)
-                    + ((0x80 & buf[idx - 1]) ? 1900 : 2000);
+      std::uint8_t dd = buf[idx++] & 0x3f;
+      std::uint8_t wd = buf[idx++] & 0x07;
+      std::uint8_t mo = buf[idx] & 0x1f;
+      bool century    = buf[idx++] & 0x80;
+      std::uint8_t yy = buf[idx];
+      if (!isValidBcd(dd) || !isValidBcd(mo) || !isValidBcd(yy))
+      {
+        return false;
+      }
+      d.date    = bcd2ToByte(dd);
+      d.weekDay = wd;
+      d.month   = bcd2ToByte(mo);
+      d.year    = bcd2ToByte(yy) + (century ? 1900 : 2000);
     }
+
+    if (!validateDateTime(date ? &d : nullptr, time ? &t : nullptr))
+    {
+      return false;
+    }
+    if (time) { *time = t; }
+    if (date) { *date = d; }
     return true;
   }
 

--- a/src/utility/rtc/RTC_Base.cpp
+++ b/src/utility/rtc/RTC_Base.cpp
@@ -28,4 +28,21 @@ namespace m5
     date = rtc_date_t { datetime };
     time = rtc_time_t { datetime };
   }
+
+  bool RTC_Base::validateDateTime(const rtc_date_t* date, const rtc_time_t* time)
+  {
+    if (time && (time->seconds > 59 || time->seconds < 0
+              || time->minutes > 59 || time->minutes < 0
+              || time->hours   > 23 || time->hours   < 0))
+    {
+      return false;
+    }
+    if (date && (date->date  < 1 || date->date  > 31
+              || date->month < 1 || date->month > 12
+              || date->weekDay < 0 || date->weekDay > 6))
+    {
+      return false;
+    }
+    return true;
+  }
 }

--- a/src/utility/rtc/RTC_Base.hpp
+++ b/src/utility/rtc/RTC_Base.hpp
@@ -100,6 +100,18 @@ namespace m5
     virtual void disableIRQ(void) {};
 
     virtual bool getVoltLow(void) { return false; }
+
+  protected:
+    /// Check that both nibbles of a (masked) register byte are valid BCD.
+    /// A corrupted I2C read (e.g. 0xFF) would otherwise decode to a
+    /// plausible-looking but impossible value such as year 2165.
+    static bool isValidBcd(std::uint8_t value)
+    {
+      return ((value & 0x0F) <= 9) && ((value >> 4) <= 9);
+    }
+
+    /// Range-check decoded values before committing them to the output.
+    static bool validateDateTime(const rtc_date_t* date, const rtc_time_t* time);
   };
 }
 

--- a/src/utility/rtc/RX8130_Class.cpp
+++ b/src/utility/rtc/RX8130_Class.cpp
@@ -45,18 +45,49 @@ namespace m5
       return false;
     }
 
+    // Decode into locals and validate before committing, so that a corrupted
+    // register value (I2C glitch, uninitialized RTC) results in false instead
+    // of a bogus date such as 45:00:80 or year 2165.
     int idx = 0;
+    rtc_time_t t;
     if (time) {
-      time->seconds = bcd2ToByte(buf[idx++] & 0x7f);
-      time->minutes = bcd2ToByte(buf[idx++] & 0x7f);
-      time->hours   = bcd2ToByte(buf[idx++] & 0x3f);
+      std::uint8_t sec  = buf[idx++] & 0x7f;
+      std::uint8_t min  = buf[idx++] & 0x7f;
+      std::uint8_t hour = buf[idx++] & 0x3f;
+      if (!isValidBcd(sec) || !isValidBcd(min) || !isValidBcd(hour))
+      {
+        return false;
+      }
+      t.seconds = bcd2ToByte(sec);
+      t.minutes = bcd2ToByte(min);
+      t.hours   = bcd2ToByte(hour);
     }
+
+    rtc_date_t d;
     if (date) {
-      date->weekDay = __builtin_ctz(buf[idx++]);
-      date->date    = bcd2ToByte(buf[idx++] & 0x3f);
-      date->month   = bcd2ToByte(buf[idx++] & 0x1f);
-      date->year    = bcd2ToByte(buf[idx] & 0xff) + 2000;
+      // The weekday register holds a single bit for the current day; anything
+      // else is invalid. (Also guards __builtin_ctz(0), which is undefined.)
+      std::uint8_t wd = buf[idx++];
+      std::uint8_t dd = buf[idx++] & 0x3f;
+      std::uint8_t mo = buf[idx++] & 0x1f;
+      std::uint8_t yy = buf[idx];
+      if (wd == 0 || (wd & (wd - 1)) != 0
+       || !isValidBcd(dd) || !isValidBcd(mo) || !isValidBcd(yy))
+      {
+        return false;
+      }
+      d.weekDay = __builtin_ctz(wd);
+      d.date    = bcd2ToByte(dd);
+      d.month   = bcd2ToByte(mo);
+      d.year    = bcd2ToByte(yy) + 2000;
     }
+
+    if (!validateDateTime(date ? &d : nullptr, time ? &t : nullptr))
+    {
+      return false;
+    }
+    if (time) { *time = t; }
+    if (date) { *date = d; }
     return true;
   }
 


### PR DESCRIPTION
Fixes #156

## Problem

`getDateTime()` decoded the RTC's BCD registers without any validation. A corrupted read (I2C glitch) or an uninitialized RTC therefore produced impossible values — e.g. `45:00:80` or year `2165` (0xFF decoded as BCD) — while still returning `true`, so callers had no way to notice the value was garbage. This matches the reported symptom of wildly wrong dates being displayed.

Additionally, the RX8130 path computed `weekDay = __builtin_ctz(reg)` without checking the register, which is undefined behavior when the weekday register reads 0.

## Fix

- Add two helpers to `RTC_Base`: a BCD digit check for masked register bytes, and a range check for the decoded fields (seconds/minutes/hours, date 1–31, month 1–12, weekDay 0–6).
- PCF8563 and RX8130 `getDateTime()` now decode into locals, validate, and only commit to the caller's output when everything is plausible; otherwise they return `false` and leave the output untouched.
- The RX8130 weekday register must have exactly one of bits 0–6 set; zero, multiple bits, and bit 7 corruption are all rejected, which also guards the `__builtin_ctz(0)` case.

This is a safety net for the reported symptom, not a fix for the underlying I2C corruption. `RTC_PowerHub_Class` is out of scope here: it uses plain binary registers and already guards its `ctz(0)` case.

## Verification

Reproduced the symptom and verified the fix on real hardware by injecting invalid values directly into the RTC registers over I2C, then reading through `M5.Rtc.getDateTime()`:

| Device (RTC) | Build | normal | after injecting 0xFA/0xFF | after restoring the time |
|---|---|---|---|---|
| ToughC5 (RX8130) | before | true, correct | **true, `2165/25/17 45:00:80`** | true, correct |
| ToughC5 (RX8130) | this PR | true, correct | **false, output untouched** | true, correct |
| StickC Plus2 (BM8563/PCF8563) | this PR | true, correct | **false, output untouched** | true, correct |

Injecting `0x00` into the RX8130 weekday register produced `weekDay = -1` on the unmodified build (the `ctz(0)` UB in action); the fixed build rejects it with `false`.

As a bonus, one test unit happened to have a never-initialized BM8563: the fixed build correctly returned `false` for its garbage registers until the time was set, instead of reporting a bogus date as before.

Also build-tested on ESP-IDF v5.5 (non-Arduino path).

Limitations: validation is per-field (BCD digits + value ranges). Combinations that are individually in range (e.g. Feb 31), corruption that lands on a valid value, and the PCF8563 VL / RX8130 VLF low-voltage flags are intentionally not part of this change.
