### PR TITLE
PM1: expose PWR_SRC as a bitmap

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -2531,8 +2531,9 @@ namespace m5
 #if defined (CONFIG_IDF_TARGET_ESP32S3)
         case board_t::board_M5PaperMono:
         {
-          // Running from battery (no external power) -> not charging.
-          if (M5pm1.getPowerSource() == M5PM1_Class::battery) { return is_charging_t::is_discharging; }
+          // No external power -> not charging. PWR_SRC is a bitmap, and the battery bit may coexist with VIN.
+          auto sources = M5pm1.getPowerSource();
+          if (!(sources & (M5PM1_Class::vin | M5PM1_Class::vinout))) { return is_charging_t::is_discharging; }
           // External power present. The IP2316 charger reports
           // its state in REG_CHG_STAT(0xC7): bit7 = charging in progress (measured:
           // 0x82 charging / 0x45 charge-complete / 0x00 charge-disabled).

--- a/src/utility/power/M5PM1_Class.cpp
+++ b/src/utility/power/M5PM1_Class.cpp
@@ -99,9 +99,8 @@ namespace m5
 
   M5PM1_Class::pwr_src_t M5PM1_Class::getPowerSource(void)
   {
-    if (!_init) { return unknown; }
-    auto src = readRegister8(M5PM1_REG_PWR_SRC) & 0x07;
-    return src <= static_cast<std::uint8_t>(battery) ? static_cast<pwr_src_t>(src) : unknown;
+    if (!_init) { return none; }
+    return static_cast<pwr_src_t>(readRegister8(M5PM1_REG_PWR_SRC) & 0x07);
   }
 
   bool M5PM1_Class::getVbatNodePowered(bool* powered)

--- a/src/utility/power/M5PM1_Class.hpp
+++ b/src/utility/power/M5PM1_Class.hpp
@@ -55,12 +55,12 @@ namespace m5
     , open_drain = 1
     };
 
-    /// PM1 power source status.
+    /// PM1 power source bitmap. Multiple values may be combined.
     enum pwr_src_t : std::uint8_t
-    { vin     = 0
-    , vinout  = 1
-    , battery = 2
-    , unknown = 3
+    { none    = 0
+    , vin     = 1 << 0
+    , vinout  = 1 << 1
+    , battery = 1 << 2
     };
 
     /// set BOOST/Grove 5V output enable.
@@ -82,7 +82,9 @@ namespace m5
     /// @param level true=high / false=low
     bool setLedEnLevel(bool level);
 
-    /// get current PM1 power source.
+    /// get the PM1 PWR_SRC bitmap.
+    /// bit0=5VIN valid, bit1=5VINOUT valid (0 while the 5V boost is enabled),
+    /// bit2=VBAT node valid. Multiple sources may be present simultaneously.
     pwr_src_t getPowerSource(void);
 
     /// get whether PWR_SRC reports the VBAT node rail as powered.


### PR DESCRIPTION
## Problem

`M5PM1_Class::getPowerSource()` treated the PWR_SRC register (0x04) as an exclusive enum (`value & 0x07` compared against 0/1/2). The PM1 datasheet defines this register as a **Power Source Bitmap** — bit0 = 5VIN valid, bit1 = 5VINOUT valid (reads 0 while the 5V boost is enabled), bit2 = VBAT node valid, and multiple sources may be present simultaneously. On a battery-equipped board under USB power the register reads e.g. 0x05 (5VIN + BAT), so the old API returned `unknown` even while externally powered.

Measured on a real M5PaperColor (PM1 rev 20.05.53, USB + battery connected): PWR_SRC = 0x05, VIN = 3.3 V, VBAT = 3.7 V, 5VINOUT = 5.0 V.

## Fix

Rather than deriving a single "primary" source (a priority the datasheet does not define), the API now exposes the bitmap directly:

- `pwr_src_t` is redefined as a bitmap: `none = 0`, `vin = 1<<0`, `vinout = 1<<1`, `battery = 1<<2`, matching the datasheet layout. `getPowerSource()` returns the OR of the bits, so callers can test each source directly (`src & M5PM1_Class::vin`).
- The one in-tree user (PaperMono `isCharging()`) is updated accordingly: "no external power → discharging" is now a bit test instead of an exclusive comparison that broke whenever the battery bit coexisted with VIN.

This is a breaking change to `pwr_src_t` values, made deliberately: the previous decoding returned wrong values for every real-world register state, so no caller could have been relying on it correctly.

## Verification

On the M5PaperColor above, `getPowerSource()` now returns 0x05 with `vin` and `battery` set and `vinout` clear, matching the raw register. Build-tested on Arduino (ESP32-S3, core 3.3.4) and ESP-IDF v5.5.

Related: #307.
