### PR TITLE
Tab5: fix the battery current sign

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -2423,7 +2423,9 @@ namespace m5
       switch (M5.getBoard()) {
 #if defined (CONFIG_IDF_TARGET_ESP32P4)
       case board_t::board_M5Tab5:
-        return 1000.0f * Ina226.getShuntCurrent();
+        // The shunt is wired so that charge current reads negative; invert to
+        // match the documented convention (+ = charge / - = discharge).
+        return -1000.0f * Ina226.getShuntCurrent();
 #endif
 
 #if defined (CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
`getBatteryCurrent()` documents "+ = charge / - = discharge", but on the Tab5 the INA226 shunt is wired so that charging reads negative.

Verified on real hardware: with a discharged pack under USB power — voltage steadily rising and the charge status asserted, i.e. unambiguously charging — the API returned about -650 mA. With this change it returns about +613 mA under the same conditions, matching the documented convention. The StampPLC external-port measurement path is a different board and wiring and is intentionally untouched.

Related: #173.