### PR TITLE
Add PM1 PWM control and use it for the ToughC5 buzzer

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -275,6 +275,35 @@ namespace m5
       _wakeupPin = GPIO_NUM_4;
       /// bring up the PM1 early so its status registers are readable below.
       M5pm1.begin();
+      /// GPIO4 drives the buzzer through PM1 PWM channel 1. The PM1 keeps
+      /// running across ESP resets and retains its PWM state, so put the
+      /// channel off at boot, then normalize the pin before selecting its PWM
+      /// function. Stopping the channel before sleep is left to the caller:
+      /// the PM1 stays powered while the ESP sleeps, so the application may
+      /// intend the PWM output to remain active, which makes it application
+      /// policy rather than board initialization.
+      /// Selecting the PWM function is what makes a retained duty audible
+      /// again, so it is only done once the channel is known to be off. If that
+      /// cannot be confirmed, the pin is left as a plain output driving low,
+      /// which is silent whatever the retained PWM state is.
+      bool pwm_off = false;
+      for (int retry = 3; !(pwm_off = M5pm1.setPwmDuty12bit(M5PM1_Class::pwm_ch1, 0, false, false)) && --retry; )
+      {
+        m5gfx::delay(10);
+      }
+      M5pm1.setGPIODrive(M5PM1_Class::gpio4, M5PM1_Class::push_pull);
+      M5pm1.setGPIOPull(M5PM1_Class::gpio4, M5PM1_Class::pull_none);
+      M5pm1.setGPIOOutput(M5PM1_Class::gpio4, false);
+      M5pm1.setGPIOMode(M5PM1_Class::gpio4, M5PM1_Class::output);
+      if (pwm_off)
+      {
+        M5pm1.setGPIOFunction(M5PM1_Class::gpio4, M5PM1_Class::special);
+      }
+      else
+      {
+        M5_LOGE("PM1 PWM ch1 could not be turned off. Leaving GPIO4 as a low output.");
+        M5pm1.setGPIOFunction(M5PM1_Class::gpio4, M5PM1_Class::gpio);
+      }
       /// PM1 は常時給電で ESP のリセットを跨いで状態が残るため、直前に動いて
       /// いたファームの設定に依存しないよう IRQ 関連を初期化する
       M5pm1.clearWakeSource();

--- a/src/utility/power/M5PM1_Class.cpp
+++ b/src/utility/power/M5PM1_Class.cpp
@@ -30,6 +30,8 @@ namespace m5
   static constexpr const uint8_t M5PM1_REG_VBAT_L      = 0x22;
   static constexpr const uint8_t M5PM1_REG_VIN_L       = 0x24;
   static constexpr const uint8_t M5PM1_REG_5VOUT_L     = 0x26;
+  static constexpr const uint8_t M5PM1_REG_PWM0_L      = 0x30;
+  static constexpr const uint8_t M5PM1_REG_PWM_FREQ_L  = 0x34;
   static constexpr const uint8_t M5PM1_REG_IRQ_STATUS1 = 0x40;
   static constexpr const uint8_t M5PM1_REG_IRQ_STATUS2 = 0x41;
   static constexpr const uint8_t M5PM1_REG_IRQ_STATUS3 = 0x42;
@@ -43,6 +45,8 @@ namespace m5
   static constexpr const uint8_t M5PM1_PWR_CFG_BOOST_EN = 1 << 3;
   static constexpr const uint8_t M5PM1_PWR_CFG_LED_EN   = 1 << 4;
   static constexpr const uint8_t M5PM1_SYS_CMD_SHUTDOWN = 0xA1;
+  static constexpr const uint8_t M5PM1_PWM_ENABLE       = 1 << 4;
+  static constexpr const uint8_t M5PM1_PWM_POLARITY     = 1 << 5;
 
   static constexpr bool is_valid_gpio(M5PM1_Class::gpio_t pin)
   {
@@ -52,6 +56,11 @@ namespace m5
   static constexpr std::uint8_t gpio_num(M5PM1_Class::gpio_t pin)
   {
     return static_cast<std::uint8_t>(pin);
+  }
+
+  static constexpr bool is_valid_pwm_channel(M5PM1_Class::pwm_channel_t channel)
+  {
+    return static_cast<std::uint8_t>(channel) <= M5PM1_Class::pwm_ch1;
   }
 
   bool M5PM1_Class::begin(void)
@@ -173,6 +182,33 @@ namespace m5
   {
     if (!_init || !is_valid_gpio(pin)) { return false; }
     return readRegister8(M5PM1_REG_GPIO_OUT) & (1 << gpio_num(pin));
+  }
+
+  bool M5PM1_Class::setPwmFrequency(std::uint16_t frequency)
+  {
+    std::uint8_t data[2] =
+    { static_cast<std::uint8_t>(frequency & 0xFF)
+    , static_cast<std::uint8_t>(frequency >> 8)
+    };
+    return writeRegister(M5PM1_REG_PWM_FREQ_L, data, sizeof(data));
+  }
+
+  bool M5PM1_Class::setPwmDuty(pwm_channel_t channel, std::uint8_t duty, bool polarity, bool enable)
+  {
+    if (duty > 100) { return false; }
+    auto duty12 = static_cast<std::uint16_t>(static_cast<std::uint32_t>(duty) * 0x0FFF / 100);
+    return setPwmDuty12bit(channel, duty12, polarity, enable);
+  }
+
+  bool M5PM1_Class::setPwmDuty12bit(pwm_channel_t channel, std::uint16_t duty12, bool polarity, bool enable)
+  {
+    if (!is_valid_pwm_channel(channel) || duty12 > 0x0FFF) { return false; }
+    std::uint8_t high = static_cast<std::uint8_t>(duty12 >> 8);
+    if (enable) { high |= M5PM1_PWM_ENABLE; }
+    if (polarity) { high |= M5PM1_PWM_POLARITY; }
+    std::uint8_t data[2] = { static_cast<std::uint8_t>(duty12 & 0xFF), high };
+    auto reg = static_cast<std::uint8_t>(M5PM1_REG_PWM0_L + static_cast<std::uint8_t>(channel) * 2);
+    return writeRegister(reg, data, sizeof(data));
   }
 
   bool M5PM1_Class::clearWakeSource(std::uint8_t mask)

--- a/src/utility/power/M5PM1_Class.hpp
+++ b/src/utility/power/M5PM1_Class.hpp
@@ -55,6 +55,12 @@ namespace m5
     , open_drain = 1
     };
 
+    /// PM1 PWM channel. Both channels share the same frequency setting.
+    enum pwm_channel_t : std::uint8_t
+    { pwm_ch0 = 0 // GPIO3; may be assigned to another function depending on the board.
+    , pwm_ch1 = 1 // GPIO4
+    };
+
     /// PM1 power source bitmap. Multiple values may be combined.
     enum pwr_src_t : std::uint8_t
     { none    = 0
@@ -114,6 +120,25 @@ namespace m5
 
     /// get PM1 GPIO output latch level, not the physical input level.
     bool getGPIOOutputLatch(gpio_t pin);
+
+    /// set the PWM frequency in Hz.
+    /// @note The frequency is shared by both PWM channels, so changing it also
+    /// changes a channel that is already running.
+    bool setPwmFrequency(std::uint16_t frequency);
+
+    /// set PWM duty in percent.
+    /// @param channel PWM channel (pwm_ch0 / pwm_ch1).
+    /// @param duty duty cycle in percent (0-100).
+    /// @param polarity false=normal / true=inverted.
+    /// @param enable true=enable / false=disable.
+    bool setPwmDuty(pwm_channel_t channel, std::uint8_t duty, bool polarity = false, bool enable = true);
+
+    /// set PWM duty with 12-bit precision.
+    /// @param channel PWM channel (pwm_ch0 / pwm_ch1).
+    /// @param duty12 duty cycle (0-4095).
+    /// @param polarity false=normal / true=inverted.
+    /// @param enable true=enable / false=disable.
+    bool setPwmDuty12bit(pwm_channel_t channel, std::uint16_t duty12, bool polarity = false, bool enable = true);
 
     /// clear PM1 wake source bits selected by mask.
     bool clearWakeSource(std::uint8_t mask = 0x7F);


### PR DESCRIPTION
## Problem

The PM1 exposes two PWM channels but `M5PM1_Class` had no way to reach them.

On the ToughC5 this leaves the buzzer unusable: it is driven by PM1 PWM
channel 1, and nothing configures GPIO4 for that function. The PM1 also keeps
running across ESP resets and retains its PWM state, so a firmware that leaves
the channel enabled hands a sounding buzzer to whatever boots next.

## Fix

`Add PWM control to M5PM1_Class` adds the frequency and duty setters. The
naming and the units follow the standalone M5PM1 driver so code can move
between the two: `setPwmDuty` takes percent, `setPwmDuty12bit` takes the raw
12-bit value, and the boolean arguments are ordered polarity then enable. The
return value is `bool` for the I2C result, matching the rest of the class.
Both channels share one frequency register, which the doc comment states.

`Configure the ToughC5 buzzer line at startup` sets the pin up. The channel is
put off at boot, the same way the vibration motor is on the StopWatch, and the
output latch is cleared before GPIO4 becomes an output so the pin never drives
the buzzer directly while the PWM function is being selected.

Stopping the channel before sleep is deliberately left to the application, in
line with how the StopWatch motor is handled: the PM1 stays powered while the
ESP sleeps, so the output may be meant to keep running.

The second commit sits inside the ESP32-C5 target guard and a board check, so
other boards are untouched.

## Verification

Built for ESP32-C5 and for ESP32, and the first commit builds on its own.

On ToughC5 hardware: tones across the audible range, which also confirmed the
frequency register takes a plain value in Hz. The startup shutdown was checked
by leaving the buzzer sounding, flashing over it while it sounded, and
confirming it went quiet once the new firmware reached `begin()`.
