### PR TITLE
Align the M5IOE1_Class PWM API with the standalone drivers (breaking)

### DIFF
--- a/src/utility/M5IOE1_Class.cpp
+++ b/src/utility/M5IOE1_Class.cpp
@@ -111,21 +111,28 @@ namespace m5
     return true;
   }
 
-  void M5IOE1_Class::setPwmFrequency(std::uint16_t frequency)
+  bool M5IOE1_Class::setPwmFrequency(std::uint16_t frequency)
   {
     std::uint8_t data[2] = { static_cast<std::uint8_t>(frequency & 0xFF), static_cast<std::uint8_t>(frequency >> 8) };
-    writeRegister(M5IOE1_REG_PWM_FREQ_L, data, sizeof(data));
+    return writeRegister(M5IOE1_REG_PWM_FREQ_L, data, sizeof(data));
   }
 
-  void M5IOE1_Class::setPwmDuty(std::uint8_t channel, std::uint16_t duty12, bool enable, bool polarity)
+  bool M5IOE1_Class::setPwmDuty(pwm_channel_t channel, std::uint8_t duty, bool polarity, bool enable)
   {
-    if (channel > pwm_ch4) { return; }
-    duty12 &= 0x0FFF;
+    if (duty > 100) { return false; }
+    auto duty12 = static_cast<std::uint16_t>(static_cast<std::uint32_t>(duty) * 0x0FFF / 100);
+    return setPwmDuty12bit(channel, duty12, polarity, enable);
+  }
+
+  bool M5IOE1_Class::setPwmDuty12bit(pwm_channel_t channel, std::uint16_t duty12, bool polarity, bool enable)
+  {
+    if (channel > pwm_ch4 || duty12 > 0x0FFF) { return false; }
     std::uint8_t high = static_cast<std::uint8_t>(duty12 >> 8);
     if (enable) { high |= M5IOE1_PWM_ENABLE; }
     if (polarity) { high |= M5IOE1_PWM_POLARITY; }
     std::uint8_t data[2] = { static_cast<std::uint8_t>(duty12 & 0xFF), high };
-    writeRegister(static_cast<std::uint8_t>(M5IOE1_REG_PWM1_DUTY_L + channel * 2), data, sizeof(data));
+    auto reg = static_cast<std::uint8_t>(M5IOE1_REG_PWM1_DUTY_L + static_cast<std::uint8_t>(channel) * 2);
+    return writeRegister(reg, data, sizeof(data));
   }
 
   void M5IOE1_Class::resetIrq()

--- a/src/utility/M5IOE1_Class.hpp
+++ b/src/utility/M5IOE1_Class.hpp
@@ -59,9 +59,24 @@ namespace m5
     bool digitalRead(uint8_t pin) override;
     bool getInputLevel(uint8_t pin, bool* level) override;
 
-    void setPwmFrequency(std::uint16_t frequency);
+    /// set the PWM frequency in Hz.
+    /// @note The frequency is shared by all PWM channels, so changing it also
+    /// changes a channel that is already running.
+    bool setPwmFrequency(std::uint16_t frequency);
 
-    void setPwmDuty(std::uint8_t channel, std::uint16_t duty12, bool enable = true, bool polarity = false);
+    /// set PWM duty in percent.
+    /// @param channel PWM channel (pwm_ch1 - pwm_ch4).
+    /// @param duty duty cycle in percent (0-100).
+    /// @param polarity false=normal / true=inverted.
+    /// @param enable true=enable / false=disable.
+    bool setPwmDuty(pwm_channel_t channel, std::uint8_t duty, bool polarity = false, bool enable = true);
+
+    /// set PWM duty with 12-bit precision.
+    /// @param channel PWM channel (pwm_ch1 - pwm_ch4).
+    /// @param duty12 duty cycle (0-4095).
+    /// @param polarity false=normal / true=inverted.
+    /// @param enable true=enable / false=disable.
+    bool setPwmDuty12bit(pwm_channel_t channel, std::uint16_t duty12, bool polarity = false, bool enable = true);
 
     void resetIrq() override;
 

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -402,7 +402,7 @@ namespace m5
         // IO9 (G9 motor / PWM1): push-pull output, duty off until setVibration
         ioe1.setHighImpedance(M5IOE1_Class::gpio9, false);
         ioe1.setDirection(M5IOE1_Class::gpio9, true);
-        ioe1.setPwmDuty(M5IOE1_Class::pwm_ch1, 0, false);  // PWM off at boot
+        ioe1.setPwmDuty12bit(M5IOE1_Class::pwm_ch1, 0, false, false);  // PWM off at boot
       }
       break;
 
@@ -2780,13 +2780,13 @@ namespace m5
       // M5IOE1 PWM1 (0x1B/0x1C) -> pin IO9 / G9 motor; duty 12-bit in [11:0], EN=bit7 of high byte.
       auto& ioe1 = static_cast<M5IOE1_Class&>(M5.getIOExpander(0));
       if (level == 0) {
-        ioe1.setPwmDuty(M5IOE1_Class::pwm_ch1, 0, false);
+        ioe1.setPwmDuty12bit(M5IOE1_Class::pwm_ch1, 0, false, false);
       } else {
         // PWM needs IO9 in output mode (M5IOE1 pin index 8 -> GPIO_MODE_H bit0).
         ioe1.setHighImpedance(M5IOE1_Class::gpio9, false);
         ioe1.setDirection(M5IOE1_Class::gpio9, true);
         uint16_t duty12 = static_cast<uint16_t>((static_cast<uint32_t>(level) * 0x0FFFu) / 255u);
-        ioe1.setPwmDuty(M5IOE1_Class::pwm_ch1, duty12);
+        ioe1.setPwmDuty12bit(M5IOE1_Class::pwm_ch1, duty12);
       }
       return;
     }

--- a/src/utility/led/LED_PaperMono_Class.cpp
+++ b/src/utility/led/LED_PaperMono_Class.cpp
@@ -76,7 +76,7 @@ namespace m5
     ioe1.digitalWrite(ioe1_led_b_pin, b >= 2048);
 
     if (g > 4095) { g = 4095; }
-    ioe1.setPwmDuty(M5IOE1_Class::pwm_ch2, g, g > 0);
+    ioe1.setPwmDuty12bit(M5IOE1_Class::pwm_ch2, g, false, g > 0);
   }
 }
 


### PR DESCRIPTION
## Problem

`M5IOE1_Class::setPwmDuty` takes the raw 12-bit value under the name the
standalone M5IOE1 and M5PM1 drivers use for percent, and it orders its two
booleans the other way round.

```cpp
// standalone m5stack/M5IOE1 and m5stack/M5PM1
setPwmDuty(channel, duty /* 0-100 */, polarity = false, enable = true);
setPwmDuty12bit(channel, duty12, polarity = false, enable = true);

// M5IOE1_Class before this change
setPwmDuty(channel, duty12 /* 0-4095 */, enable = true, polarity = false);
```

Reading the M5IOE1 documentation and writing `setPwmDuty(ch, 50, false, true)`
against this class compiles and quietly means "duty 50 out of 4095, disabled"
instead of "50 percent, enabled". Both parameters being `bool` makes the swap
invisible.

`M5PM1_Class` gained its PWM API in #318 and follows the standalone drivers, so
this class is now the only one that differs.

## Fix

The raw entry point becomes `setPwmDuty12bit` and `setPwmDuty` takes percent,
matching both standalone drivers. The boolean order is polarity then enable, the
channel is the existing enum rather than a bare integer, the setters report the
I2C result instead of returning `void`, and an out of range duty is rejected
rather than masked.

The register layout stays as it is: only the API shape is aligned, the enable
and polarity bit positions remain the ones this chip uses.

## Breaking change

Callers of `setPwmDuty` have to move raw duties to `setPwmDuty12bit` and reorder
the booleans. The compiler catches only the calls that passed a bare integer as
the channel; calls written against the enum keep compiling while changing
meaning:

- a raw duty that happens to be 0-100 is taken as a percentage
- a larger one is narrowed to `uint8_t` before the range check, so a value whose
  low byte lands in 0-100 goes through at that percentage
- a third argument that used to disable the channel now sets the polarity, and
  the channel stays enabled by default

Keeping the old signature under `[[deprecated]]` is not an option: overloading
`(channel, uint16_t, bool, bool)` against `(channel, uint8_t, bool, bool)` makes
literal calls ambiguous or silently pick the wrong one, which trades one trap
for another.

Intended for the next release, bumping the minor version to 0.3.0.

## Verification

Built for ESP32-S3, ESP32-C5 and ESP32. The S3 build is the one that matters:
every call site of this API is inside an S3 guard, and all four are updated in
this commit so the change stays bisectable.
