### PR TITLE
Replace the IO expander pull enable API with explicit modes

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -2170,13 +2170,13 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
         auto& ioexp = getIOExpander(0);
         // lcd backlight
         ioexp.setDirection(7, true);
-        ioexp.setPullMode(7, false);
+        ioexp.setPullMode(7, IOExpander_Base::pull_down);
         ioexp.setHighImpedance(7, false);
   
         for (int i = 0; i < 3; ++i) {
           // button a~c
           ioexp.setDirection(i, false);
-          ioexp.setPullMode(i, true);
+          ioexp.setPullMode(i, IOExpander_Base::pull_up);
           ioexp.setHighImpedance(i, false);
         }
         delay(100);

--- a/src/utility/IOExpander_Base.hpp
+++ b/src/utility/IOExpander_Base.hpp
@@ -12,6 +12,12 @@ namespace m5
   class IOExpander_Base : public I2C_Device
   {
   public:
+    enum gpio_pull_t : std::uint8_t
+    { pull_none = 0
+    , pull_up   = 1
+    , pull_down = 2
+    };
+
     IOExpander_Base(std::uint8_t i2c_addr, std::uint32_t freq = 400000, m5::I2C_Class* i2c = &m5::In_I2C)
       : I2C_Device(i2c_addr, freq, i2c)
     {}
@@ -20,10 +26,10 @@ namespace m5
     // false input, true output
     virtual void setDirection(uint8_t pin, bool direction) = 0;
 
-    virtual void enablePull(uint8_t pin, bool enablePull) = 0;
-
-    // false down, true up
-    virtual void setPullMode(uint8_t pin, bool mode) = 0;
+    /// Set the GPIO pull resistor state.
+    /// @return true only when the requested state was completely established;
+    /// false for an invalid pin, mode, or I2C failure.
+    virtual bool setPullMode(uint8_t pin, gpio_pull_t mode) = 0;
 
     virtual void setHighImpedance(uint8_t pin, bool enable) = 0;
 

--- a/src/utility/M5IOE1_Class.cpp
+++ b/src/utility/M5IOE1_Class.cpp
@@ -48,29 +48,27 @@ namespace m5
     direction ? bitOn(reg, bit) : bitOff(reg, bit);
   }
 
-  void M5IOE1_Class::enablePull(uint8_t pin, bool enablePull)
+  bool M5IOE1_Class::setPullMode(uint8_t pin, gpio_pull_t mode)
   {
-    if (!_isValidPin(pin)) { return; }
+    if (!_isValidPin(pin)) { return false; }
     const auto pu_reg = _regForPin(M5IOE1_REG_GPIO_PU_L, pin);
     const auto pd_reg = _regForPin(M5IOE1_REG_GPIO_PD_L, pin);
     const auto bit = _bitForPin(pin);
-    if (enablePull) {
-      bitOn(pu_reg, bit);
-    } else {
-      bitOff(pu_reg, bit);
-      bitOff(pd_reg, bit);
+    switch (mode) {
+    case pull_none: {
+      const bool pu_ok = bitOff(pu_reg, bit);
+      const bool pd_ok = bitOff(pd_reg, bit);
+      return pu_ok && pd_ok;
     }
-  }
-
-  void M5IOE1_Class::setPullMode(uint8_t pin, bool mode)
-  {
-    if (!_isValidPin(pin)) { return; }
-    const auto pu_reg = _regForPin(M5IOE1_REG_GPIO_PU_L, pin);
-    const auto pd_reg = _regForPin(M5IOE1_REG_GPIO_PD_L, pin);
-    const auto bit = _bitForPin(pin);
-    // false=pull-down, true=pull-up.
-    mode ? bitOn(pu_reg, bit) : bitOff(pu_reg, bit);
-    mode ? bitOff(pd_reg, bit) : bitOn(pd_reg, bit);
+    case pull_up:
+      if (!bitOff(pd_reg, bit)) { return false; }
+      return bitOn(pu_reg, bit);
+    case pull_down:
+      if (!bitOff(pu_reg, bit)) { return false; }
+      return bitOn(pd_reg, bit);
+    default:
+      return false;
+    }
   }
 
   void M5IOE1_Class::setHighImpedance(uint8_t pin, bool enable)

--- a/src/utility/M5IOE1_Class.hpp
+++ b/src/utility/M5IOE1_Class.hpp
@@ -46,9 +46,7 @@ namespace m5
 
     void setDirection(uint8_t pin, bool direction) override;
 
-    void enablePull(uint8_t pin, bool enablePull) override;
-
-    void setPullMode(uint8_t pin, bool mode) override;
+    bool setPullMode(uint8_t pin, gpio_pull_t mode) override;
 
     void setHighImpedance(uint8_t pin, bool enable) override;
 

--- a/src/utility/PI4IOE5V6408_Class.cpp
+++ b/src/utility/PI4IOE5V6408_Class.cpp
@@ -29,22 +29,21 @@ void PI4IOE5V6408_Class::setDirection(uint8_t pin, bool direction)
     }
 }
 
-void PI4IOE5V6408_Class::enablePull(uint8_t pin, bool enablePull)
+bool PI4IOE5V6408_Class::setPullMode(uint8_t pin, gpio_pull_t mode)
 {
-    if (enablePull) {
-        bitOn(0x0B, 1 << pin);
-    } else {
-        bitOff(0x0B, 1 << pin);
-    }
-}
-
-// false down, true up
-void PI4IOE5V6408_Class::setPullMode(uint8_t pin, bool mode)
-{
-    if (mode) {
-        bitOn(0x0D, 1 << pin);
-    } else {
-        bitOff(0x0D, 1 << pin);
+    if (pin >= 8) return false;
+    const auto bit = 1 << pin;
+    switch (mode) {
+    case pull_none:
+        return bitOff(0x0B, bit);
+    case pull_up:
+        if (!bitOn(0x0D, bit)) { return false; }
+        return bitOn(0x0B, bit);
+    case pull_down:
+        if (!bitOff(0x0D, bit)) { return false; }
+        return bitOn(0x0B, bit);
+    default:
+        return false;
     }
 }
 

--- a/src/utility/PI4IOE5V6408_Class.hpp
+++ b/src/utility/PI4IOE5V6408_Class.hpp
@@ -33,10 +33,7 @@ namespace m5
     // false input, true output
     void setDirection(uint8_t pin, bool direction) override;
 
-    void enablePull(uint8_t pin, bool enablePull) override;
-
-    // false down, true up
-    void setPullMode(uint8_t pin, bool mode) override;
+    bool setPullMode(uint8_t pin, gpio_pull_t mode) override;
 
     void setHighImpedance(uint8_t pin, bool enable) override;
 

--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -321,7 +321,7 @@ namespace m5
         auto& ioe1 = M5.getIOExpander(0);
         ioe1.setDirection(M5IOE1_Class::gpio1, false);
         ioe1.setHighImpedance(M5IOE1_Class::gpio1, true);
-        ioe1.enablePull(M5IOE1_Class::gpio1, false);
+        ioe1.setPullMode(M5IOE1_Class::gpio1, IOExpander_Base::pull_none);
         ioe1.setDirection(M5IOE1_Class::gpio3, false);
       }
       M5pm1.setBatteryCharge(true);
@@ -465,7 +465,7 @@ namespace m5
         auto& ioe1 = M5.getIOExpander(0);
         // M5IOE1_G3 -- Charge Status
         ioe1.setDirection(M5IOE1_Class::gpio3, false);
-        ioe1.enablePull(M5IOE1_Class::gpio3, false);
+        ioe1.setPullMode(M5IOE1_Class::gpio3, IOExpander_Base::pull_none);
         // M5IOE1_G4 -- Boost Control
         ioe1.setHighImpedance(M5IOE1_Class::gpio4, false);
         ioe1.setDirection(M5IOE1_Class::gpio4, true);
@@ -874,13 +874,13 @@ namespace m5
       if (port_mask & ext_port_mask_t::ext_PA)
       {
         auto& ioe = M5.getIOExpander(0);
-        ioe.setPullMode(2, enable);
+        ioe.setPullMode(2, enable ? IOExpander_Base::pull_up : IOExpander_Base::pull_down);
         ioe.digitalWrite(2, enable);
       }
       if (port_mask & ext_port_mask_t::ext_USB)
       {
         auto& ioe = M5.getIOExpander(1);
-        ioe.setPullMode(3, enable);
+        ioe.setPullMode(3, enable ? IOExpander_Base::pull_up : IOExpander_Base::pull_down);
         ioe.digitalWrite(3, enable);
       }
       break;
@@ -2331,14 +2331,14 @@ namespace m5
         auto& ioe1 = M5.getIOExpander(0);
         if (max_mA >= 650)
         {
-          ioe1.enablePull(M5IOE1_Class::gpio3, false);
+          ioe1.setPullMode(M5IOE1_Class::gpio3, IOExpander_Base::pull_none);
           ioe1.digitalWrite(M5IOE1_Class::gpio3, false);
           ioe1.setHighImpedance(M5IOE1_Class::gpio3, false);
           ioe1.setDirection(M5IOE1_Class::gpio3, true);
         }
         else
         {
-          ioe1.enablePull(M5IOE1_Class::gpio3, false);
+          ioe1.setPullMode(M5IOE1_Class::gpio3, IOExpander_Base::pull_none);
           ioe1.setDirection(M5IOE1_Class::gpio3, false);
         }
       }


### PR DESCRIPTION
## Problem

The pull resistor state of an IO expander pin was split across two virtuals:
`setPullMode` picked up or down, and `enablePull` turned pulling on or off.
What that pair means differs per expander, and neither implementation is well
served by it.

On the M5IOE1 the two share one register pair, so `setPullMode` alone already
established the state. `enablePull(pin, true)` only set the pull-up bit without
clearing the pull-down one, so calling it on a pin that was previously pulled
down left both enabled at once.

On the PI4IOE5V6408 the registers are separate and the pair genuinely has to be
used together, yet nothing in this repository ever enabled it. The pull-ups in
use work because the reset default of the enable register happens to be the
enabled side.

## Fix

`setPullMode` now takes `gpio_pull_t` and establishes the whole state in one
call, so neither the call order nor a reset default matters. The values match
the constants of the standalone M5IOE1 driver.

Writes are ordered so that two pulls are never enabled at the same time, and
the first write is checked before the second is attempted: if clearing the
opposite pull fails, the requested one is not enabled. Every partial failure
therefore either leaves the previous state alone or falls back to no pull. On
the PI4IOE5V6408 the enable register is now written explicitly rather than
assumed.

The setter reports whether the requested state was fully established, since it
takes more than one I2C write and a partial failure is what would leave a pin
in the state this change is meant to rule out. The other virtuals in
`IOExpander_Base` still return `void`; making them consistent is left for a
separate change.

## Breaking change

`enablePull` is gone and `setPullMode` takes an enum instead of a `bool`. Old
calls do not compile, because neither a `bool` nor an integer converts to the
enum implicitly.

| Old | New |
| --- | --- |
| `enablePull(pin, false)` | `setPullMode(pin, pull_none)` |
| `setPullMode(pin, true)`, with pulling enabled | `setPullMode(pin, pull_up)` |
| `setPullMode(pin, false)`, with pulling enabled | `setPullMode(pin, pull_down)` |

Intended for the next release, bumping the minor version to 0.3.0.

## Verification

Built for ESP32-S3, ESP32-P4, ESP32-C5 and ESP32. The S3 and P4 builds are the
ones that matter: every call site of this API sits behind a target guard for one
of those two, and all eight are updated in this commit so the change stays
bisectable.

Checked on a Tab5, reading the pull enable and select registers back:

- `setExtOutput(true)` and `setExtOutput(false)` still select up and down as
  before, on both of the expanders they touch
- all three modes reach the registers, including the enable bit dropping for
  `pull_none` and being set explicitly for the other two, which is what removes
  the dependency on the reset default
- pins other than the one addressed are left alone
- the setter returns true for all three modes
