### PR TITLE
Report M5IOE1 PWM frequency write results

### DIFF
--- a/src/utility/M5IOE1_Class.cpp
+++ b/src/utility/M5IOE1_Class.cpp
@@ -109,10 +109,10 @@ namespace m5
     return true;
   }
 
-  void M5IOE1_Class::setPwmFrequency(std::uint16_t frequency)
+  bool M5IOE1_Class::setPwmFrequency(std::uint16_t frequency)
   {
     std::uint8_t data[2] = { static_cast<std::uint8_t>(frequency & 0xFF), static_cast<std::uint8_t>(frequency >> 8) };
-    writeRegister(M5IOE1_REG_PWM_FREQ_L, data, sizeof(data));
+    return writeRegister(M5IOE1_REG_PWM_FREQ_L, data, sizeof(data));
   }
 
   bool M5IOE1_Class::setPwmDutyPercent(pwm_channel_t channel, std::uint32_t duty,

--- a/src/utility/M5IOE1_Class.hpp
+++ b/src/utility/M5IOE1_Class.hpp
@@ -58,7 +58,10 @@ namespace m5
     bool digitalRead(uint8_t pin) override;
     bool getInputLevel(uint8_t pin, bool* level) override;
 
-    void setPwmFrequency(std::uint16_t frequency);
+    /// set the PWM frequency in Hz.
+    /// @note The frequency is shared by all PWM channels, so changing it also
+    /// changes a channel that is already running.
+    bool setPwmFrequency(std::uint16_t frequency);
 
     /// set PWM duty in percent.
     /// @param channel PWM channel (pwm_ch1 - pwm_ch4).


### PR DESCRIPTION
Return the I2C write status from `M5IOE1_Class::setPwmFrequency` instead of
discarding it, and document that the configured frequency is shared by every
PWM channel, so setting it for one channel also retunes a channel that is
already running.

This was part of #319 and was then carried inside #321 until review flagged it
as an undocumented API change there. It is a public API decision of its own
rather than part of the duty renames, so it gets its own change where the exact
compatibility story can be stated.

## Breaking change

The return type changes from `void` to `bool`. Ordinary calls that discard the
result stay source-compatible; only code that depends on the exact
member-function type has to move from `void (M5IOE1_Class::*)(std::uint16_t)`
to `bool (M5IOE1_Class::*)(std::uint16_t)`.

`M5PM1_Class::setPwmFrequency` already returns `bool`, so the two classes now
agree, and a caller can find out that the write never reached the chip instead
of proceeding on a stale frequency.

Intended for the next release, bumping the minor version to 0.3.0.

## Verification

Built for ESP32, ESP32-S3, ESP32-P4 and ESP32-C5 on top of the current develop.
