### PR TITLE
Flush the final partial speaker buffer

### DIFF
--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -739,7 +739,11 @@ label_next_wav:
             { // nothing to do; a writer caught mid-publish raises the bit itself.
               ch_info->diff = 0;
               ch_info->index = 0;
-              if (flush_partial && data_length < idx) { data_length = idx; }
+              if (flush_partial)
+              { // Keep I2S words aligned and avoid a trailing half-word on HW v1.
+                const size_t flush_length = (idx + 1) & ~size_t{1};
+                if (data_length < flush_length) { data_length = flush_length; }
+              }
               continue;
             }
             self->_play_channel_bits.fetch_or(1 << ch);

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -682,6 +682,7 @@ namespace m5
         uint8_t next_state = ch_info->wavinfo[flip].state.load(std::memory_order_acquire);
 
         size_t idx = 0;
+        bool flush_partial = false;
 
         if (current_wav->repeat == 0
          || ((next_state & (wav_phase_mask | wav_state_stop_current)) == (wav_phase_published | wav_state_stop_current)))
@@ -703,6 +704,7 @@ label_next_wav:
               // further below, once flip has moved off of it - freeing it
               // here would let a writer claim it while flip still points at
               // it, and the later retirement would wipe that claim out.
+              flush_partial = false;
               current_wav->clear();
             }
             // the finished (or cut) request goes back to the writers before
@@ -737,6 +739,7 @@ label_next_wav:
             { // nothing to do; a writer caught mid-publish raises the bit itself.
               ch_info->diff = 0;
               ch_info->index = 0;
+              if (flush_partial && data_length < idx) { data_length = idx; }
               continue;
             }
             self->_play_channel_bits.fetch_or(1 << ch);
@@ -768,6 +771,7 @@ label_wav_end:
             current_wav->repeat = --repeat;
             if (repeat == 0)
             {
+              flush_partial = true;
               goto label_next_wav;
             }
           }


### PR DESCRIPTION
## Problem

When a wav reaches its natural end partway through the speaker task's working
buffer and no follow-up request has been published, the channel loop exits
through an early `continue` before the samples already mixed into the working
buffer are counted into `data_length`. Everything generated in that final
round — up to one working buffer — is silently dropped instead of being sent
to I2S.

For a single `playRaw()` call this cuts off the tail of the sound. An
application that streams audio as consecutive short `playRaw()` chunks can
lose the tail of every chunk whenever publishing the next request loses the
race against the speaker task, which turns into periodic gaps.

## Fix

The task now tracks whether it reached the exit path through natural
exhaustion of the request. In that case the number of samples generated so
far is promoted into `data_length` (with max semantics, so other channels
mixed into the same buffer are unaffected) before the loop moves on, and the
partial buffer is transmitted as usual.

Explicit stop requests (`stop()` markers) keep the existing behavior of
discarding immediately: cutting the sound short is the point of a stop, so
nothing is flushed on that path.