### PR TITLE
Harden PWM initialization failure handling

### DIFF
--- a/src/utility/Power_Class.cpp
+++ b/src/utility/Power_Class.cpp
@@ -301,8 +301,19 @@ namespace m5
       }
       else
       {
-        M5_LOGE("PM1 PWM ch1 could not be turned off. Leaving GPIO4 as a low output.");
-        M5pm1.setGPIOFunction(M5PM1_Class::gpio4, M5PM1_Class::gpio);
+        bool gpio_fallback = false;
+        for (int retry = 3; !(gpio_fallback = M5pm1.setGPIOFunction(M5PM1_Class::gpio4, M5PM1_Class::gpio)) && --retry; )
+        {
+          m5gfx::delay(10);
+        }
+        if (gpio_fallback)
+        {
+          M5_LOGE("PM1 PWM ch1 could not be turned off. GPIO4 was switched to GPIO mode.");
+        }
+        else
+        {
+          M5_LOGE("PM1 PWM ch1 could not be turned off, and GPIO4 could not be switched to GPIO mode; silence cannot be guaranteed.");
+        }
       }
       /// PM1 は常時給電で ESP のリセットを跨いで状態が残るため、直前に動いて
       /// いたファームの設定に依存しないよう IRQ 関連を初期化する
@@ -321,7 +332,10 @@ namespace m5
         auto& ioe1 = M5.getIOExpander(0);
         ioe1.setDirection(M5IOE1_Class::gpio1, false);
         ioe1.setHighImpedance(M5IOE1_Class::gpio1, true);
-        ioe1.setPullMode(M5IOE1_Class::gpio1, IOExpander_Base::pull_none);
+        if (!ioe1.setPullMode(M5IOE1_Class::gpio1, IOExpander_Base::pull_none))
+        {
+          M5_LOGE("M5IOE1 CHG_PROG pull state could not be released.");
+        }
         ioe1.setDirection(M5IOE1_Class::gpio3, false);
       }
       M5pm1.setBatteryCharge(true);
@@ -398,11 +412,17 @@ namespace m5
         // M5IOE1: PWM1 drives IO9 (G9 motor). REG_PWM_FREQ 0x25/0x26 Hz LE; REG_PWM1_DUTY 0x1B/0x1C (bit7 EN).
         constexpr uint16_t motor_pwm_hz = 2000;
         auto& ioe1 = static_cast<M5IOE1_Class&>(M5.getIOExpander(0));
-        ioe1.setPwmFrequency(motor_pwm_hz);
-        // IO9 (G9 motor / PWM1): push-pull output, duty off until setVibration
-        ioe1.setHighImpedance(M5IOE1_Class::gpio9, false);
-        ioe1.setDirection(M5IOE1_Class::gpio9, true);
-        ioe1.setPwmDuty12bit(M5IOE1_Class::pwm_ch1, 0, pwm_polarity_t::normal, false);  // PWM off at boot
+        if (ioe1.setPwmDuty12bit(M5IOE1_Class::pwm_ch1, 0, pwm_polarity_t::normal, false))
+        {
+          ioe1.setPwmFrequency(motor_pwm_hz);
+          // IO9 (G9 motor / PWM1): push-pull output, duty off until setVibration
+          ioe1.setHighImpedance(M5IOE1_Class::gpio9, false);
+          ioe1.setDirection(M5IOE1_Class::gpio9, true);
+        }
+        else
+        {
+          M5_LOGE("M5IOE1 PWM ch1 could not be turned off. Motor output was not enabled.");
+        }
       }
       break;
 

--- a/src/utility/power/M5PM1_Class.hpp
+++ b/src/utility/power/M5PM1_Class.hpp
@@ -125,6 +125,8 @@ namespace m5
     /// set the PWM frequency in Hz.
     /// @note The frequency is shared by both PWM channels, so changing it also
     /// changes a channel that is already running.
+    /// @note PWM channel 0 maps to GPIO3 and channel 1 maps to GPIO4. Call
+    /// setGPIOFunction() with special separately to route PWM to the pin.
     bool setPwmFrequency(std::uint16_t frequency);
 
     /// set PWM duty in percent.
@@ -132,6 +134,8 @@ namespace m5
     /// @param duty duty cycle in percent (0-100).
     /// @param polarity PWM output polarity.
     /// @param enable true=enable / false=disable.
+    /// @note PWM channel 0 maps to GPIO3 and channel 1 maps to GPIO4. Call
+    /// setGPIOFunction() with special separately to route PWM to the pin.
     bool setPwmDutyPercent(pwm_channel_t channel, std::uint32_t duty,
                            pwm_polarity_t polarity = pwm_polarity_t::normal, bool enable = true);
 
@@ -140,6 +144,8 @@ namespace m5
     /// @param duty12 duty cycle (0-4095).
     /// @param polarity PWM output polarity.
     /// @param enable true=enable / false=disable.
+    /// @note PWM channel 0 maps to GPIO3 and channel 1 maps to GPIO4. Call
+    /// setGPIOFunction() with special separately to route PWM to the pin.
     bool setPwmDuty12bit(pwm_channel_t channel, std::uint32_t duty12,
                          pwm_polarity_t polarity = pwm_polarity_t::normal, bool enable = true);
 


### PR DESCRIPTION
## Problem

#318, #320 and #322 gave the PM1 / M5IOE1 PWM and pull APIs failure
reporting, but the board initialization paths still discard the results in a
few places where the whole point of the write is to rule out a retained
hardware state:

- On the ToughC5, when turning the buzzer PWM channel off fails, the fallback
  that reverts PM1 GPIO4 to plain GPIO mode is attempted once with its result
  ignored, while the error log claims the pin was left as a low output. If the
  fallback write also failed, a retained PWM state keeps the buzzer sounding
  despite the log saying otherwise.
- On the StopWatch, the motor is enabled as a push-pull output before the
  PWM duty-off write, and neither result is checked. If the duty-off write
  fails, a duty retained from the previous firmware drives the motor as soon
  as the pin is enabled.
- The ToughC5 CHG_PROG release (`setPullMode(..., pull_none)`) ignores the
  reported failure, although the comment above it states the line must stay
  released.

The PM1 PWM API also leaves its channel-to-pin mapping and the separate GPIO
function mux requirement undocumented, so a caller can get `true` from every
PWM call and still see no waveform on the pin.

## Fix

- ToughC5: the GPIO-mode fallback is retried like the PWM-off write, and the
  log now distinguishes "switched to GPIO mode" from "could not be switched;
  silence cannot be guaranteed".
- StopWatch: the duty-off write runs first, and the pin is only enabled as an
  output once it succeeds. On failure the motor output is left disabled and
  an error is logged.
- ToughC5: a failed CHG_PROG pull release is now logged.
- The three PM1 PWM methods document that channel 0 maps to GPIO3 and
  channel 1 to GPIO4, and that `setGPIOFunction()` with `special` is needed
  separately to route the PWM to the pin.

The remaining `IOExpander_Base` virtuals still return `void`; making them
consistent is left for a separate change, as noted in #320.