### PR TITLE
Use m5gfx::delay for internal hardware waits

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -481,7 +481,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     while (*bulk_data) {
       uint8_t len = *bulk_data++;
       uint8_t r = retry + 1;
-      while (!M5.In_I2C.writeRegister(i2c_addr, bulk_data[0], &bulk_data[1], len - 1, i2c_freq) && --r) { M5.delay(1); }
+      while (!M5.In_I2C.writeRegister(i2c_addr, bulk_data[0], &bulk_data[1], len - 1, i2c_freq) && --r) { m5gfx::delay(1); }
       bulk_data += len;
     }
   }
@@ -764,7 +764,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       // 状態へ落としてから終了することで、次回 enable を常に定義済み状態から始める。
       M5.In_I2C.bitOff(pi4io1_i2c_addr, 0x05, 0b00000010, 400000); // AMP off (過渡音を出さない)
       M5.In_I2C.writeRegister8(es8388_i2c_addr, 25, 0x24, 400000); // DACCONTROL3: mute (SoftRamp 維持)
-      M5.delay(1);                                                 // soft-ramp 遷移待ち
+      m5gfx::delay(1);                                             // soft-ramp 遷移待ち
       M5.In_I2C.writeRegister8(es8388_i2c_addr,  4, 0xC0, 400000); // DACPOWER: DAC L/R down + 全出力 off
       M5.In_I2C.writeRegister8(es8388_i2c_addr,  2, 0xFF, 400000); // CHIPPOWER: 全停止 (ADF deinit と同一の終端状態)
     }

--- a/src/utility/power/BQ27220_Class.cpp
+++ b/src/utility/power/BQ27220_Class.cpp
@@ -3,7 +3,7 @@
 
 #include "BQ27220_Class.hpp"
 
-#include <M5Unified.h>
+#include <M5GFX.h>
 
 #include <algorithm>
 #include <math.h>
@@ -21,7 +21,7 @@ namespace m5
       if (length == 0) {
         return true;
       }
-      M5.delay(10);
+      m5gfx::delay(10);
       if (_i2c->readRegister(_addr, 0x3E, regData, length, _freq)) {
         return true;
       }
@@ -38,7 +38,7 @@ namespace m5
       read_MuxAddrdata(0x00, 0x0001, read_data, 4);
   // printf("BQ27220 W:0x00->0x0001 R:0x%02X %02X %02X %02X\r\n", read_data[0], read_data[1], read_data[2], read_data[3]);
 
-      M5.delay(200);
+      m5gfx::delay(200);
 
       //  exit_sealed
       read_MuxAddrdata(0x00, 0x8000);


### PR DESCRIPTION
## Problem

`M5.delay()` is a plain `vTaskDelay(msec / portTICK_PERIOD_MS)`, so it
truncates to the tick period and can only undershoot. With the ESP-IDF
default tick rate of 100 Hz (10 ms tick), `M5.delay(1)` through
`M5.delay(9)` perform no delay at all — just a yield. The Arduino core's
1000 Hz tick hides this, but ESP-IDF builds use the shorter waits as
written:

- the I2C init retry backoff (`M5Unified.cpp`) becomes a busy retry loop,
- the ES8388 soft-ramp transition wait (`M5Unified.cpp`) waits for nothing,
- the BQ27220 sub-command wait of 10 ms can shrink to zero.

`m5gfx::delay()` waits coarsely with `vTaskDelay` and completes short
remainders with a microsecond busy-wait, so it guarantees at least the
requested time regardless of the tick configuration.

## Fix

Internal waits that exist for hardware timing reasons now use
`m5gfx::delay()`, matching what `Power_Class.cpp` already does everywhere.
`M5.delay()` itself is unchanged and remains the sketch-facing convenience
API.

`BQ27220_Class.cpp` referenced the global `M5` object only for these
delays, so its include narrows from `M5Unified.h` to `M5GFX.h`.