### PR TITLE
Board detection: probe the address instead of the pull-up (#330)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Display
 url=https://github.com/m5stack/M5Unified.git
 architectures=esp32
 includes=M5Unified.h
-depends=M5GFX
+depends=M5GFX (>=0.2.27)

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1368,65 +1368,100 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
   static constexpr gpio_num_t CoreInk_BUTTON_PWR_PIN = GPIO_NUM_27;
 #endif
 
-  bool M5Unified::_detect_i2c_device(uint8_t sda, uint8_t scl, uint8_t addr, const uint8_t* cmd_list)
+  bool M5Unified::_probe_i2c_addr(uint8_t sda, uint8_t scl, uint8_t addr)
   {
-    uint32_t result = 0;
 #if defined(M5UNIFIED_PC_BUILD)
-    return result;
+    return false;
 #else
-    m5gfx::gpio::pin_backup_t pin_backup[] = {scl, sda};
+    /// アドレスの存在確認はソフトウェア I2C ポートで行う (オープンドレイン駆動で
+    /// ACK 競合が起きず、ハードウェアのペリフェラルにも触れない)。
+    /// ポートは M5GFX の autodetect probe と同じ -1 を使う。負ポートは 2 本しかなく、
+    /// probe は使い終わりに release するので逐次実行なら共有できる。2 本目を
+    /// ライブラリ側で占有せず、利用者のソフト I2C バス用に空けておく。
+    static constexpr int_fast16_t probe_i2c_port = -1;
+
+    m5gfx::gpio::pin_backup_t pin_backup[] = { scl, sda };
+
+    // デバイスの電源投入直後の安定待ち。バスは解放した状態で待つ
+    // (SCL を Low に駆動したまま待つと、バスタイムアウトを持つデバイスに対して不正)。
+    m5gfx::pinMode(scl, m5gfx::pin_mode_t::input_pullup);
+    m5gfx::pinMode(sda, m5gfx::pin_mode_t::input_pullup);
+    m5gfx::delay(50);
+
+    // 前回の通信の途中で止まっているデバイスに STOP を見せて論理状態を戻す。
+    // START だけで戻らないデバイスが実在する (同ファイルの StampS3/Capsule 判別に
+    // 「STOP を出さないと正しく動作しないデバイスがあった (UnitHEART MAX30100)」の記録がある)。
+    // 線を Low へ駆動するか解放するかの 2 状態しか使わない (High を駆動しない) ので、
+    // デバイスが線を握っていてもパッド同士の衝突にはならない。
     {
-      if(cmd_list == nullptr)
+      auto line_lo = [](uint8_t pin)
+      { m5gfx::gpio_lo(pin); m5gfx::pinMode(pin, m5gfx::pin_mode_t::output); };
+      auto line_hi = [](uint8_t pin)
+      { m5gfx::pinMode(pin, m5gfx::pin_mode_t::input_pullup); };
+      for (int i = 0; i < 8; ++i)
       {
-        uint8_t cmd_low[] = {
-          m5gfx::gpio::command_write_low, scl,
-          m5gfx::gpio::command_mode_output, scl,  // SCL
-          m5gfx::gpio::command_write_low, sda,
-          m5gfx::gpio::command_mode_output, sda, // SDA
-          m5gfx::gpio::command_end,
-        };
-        m5gfx::gpio::command(cmd_low);
+        line_lo(scl); m5gfx::delayMicroseconds(5);
+        line_lo(sda); m5gfx::delayMicroseconds(5);
+        line_hi(scl); m5gfx::delayMicroseconds(5);
+        line_hi(sda); m5gfx::delayMicroseconds(5);  // SCL High 中の SDA Low->High = STOP
       }
-      else m5gfx::gpio::command(cmd_list);
+    }
 
-      delay(50);  // 延时 50ms，保证设备上电稳定
+    // 指定ピンが「外部プルアップの載った I2C バス」かどうかを先に確かめる。
+    // ここは I2C ピンとは限らない場所を駆動する機種判別なので、判定を外すと
+    // 機種の読みが変わる。判定方式は M5GFX の autodetect probe と同一のものを使う
+    // (実機での実績がある形から動かさない。変えるなら該当機種すべてで再検証が要る)。
+    //
+    // 4 回の read のうち、後半 2 回は入力プルダウンにしても High になること
+    // (= 外部プルアップが内部プルダウンに勝つこと) を確認するもの。
+    // 弱いプルアップ (内部プルダウンと同程度の抵抗値) では通らないが、
+    // 「強いプルアップがある = I2C バスである」を要求するのがこの判定の趣旨。
+    const uint8_t cmd_bus_check_list[] = {
+      m5gfx::gpio::command_write_low          , scl,
+      m5gfx::gpio::command_read               , scl,  // low チェック
+      m5gfx::gpio::command_write_low          , sda,
+      m5gfx::gpio::command_read               , sda,  // low チェック
+      m5gfx::gpio::command_mode_input_pulldown, scl,
+      m5gfx::gpio::command_delay_usec         , 10,
+      m5gfx::gpio::command_read               , scl,  // 外部プルアップがあるなら High
+      m5gfx::gpio::command_mode_input_pullup  , scl,
+      m5gfx::gpio::command_mode_input_pulldown, sda,
+      m5gfx::gpio::command_delay_usec         , 10,
+      m5gfx::gpio::command_read               , sda,  // 外部プルアップがあるなら High
+      m5gfx::gpio::command_mode_input_pullup  , sda,
+      m5gfx::gpio::command_end
+    };
+    m5gfx::pinMode(scl, m5gfx::pin_mode_t::output);
+    m5gfx::pinMode(sda, m5gfx::pin_mode_t::output);
+    if (m5gfx::gpio::command(cmd_bus_check_list) != 0x03)
+    {
+      for (auto& backup : pin_backup) { backup.restore(); }
+      return false;
+    }
 
-      for (uint8_t i2caddr : (const uint8_t[]){static_cast<uint8_t>(addr << 1)}) { //detect address
-        delay(2);  // 小延时
-        bool nack = true;
-        // I2C START
-        m5gfx::gpio_lo(sda);  // SDA LOW = START
-        for (int cycle = 0; cycle < 20; ++cycle) {
-          // SCL toggle
-          m5gfx::gpio_hi(scl);
-          delay(1);
-          m5gfx::gpio_lo(scl);
-          delay(1);
-
-          if (cycle & 1) {
-            if (cycle == 17) {
-                nack = m5gfx::gpio_in(sda);  // 读 ACK
-            }
-          } else {
-            if (i2caddr & 0x80) {
-              m5gfx::gpio_hi(sda);
-            } else {
-              m5gfx::gpio_lo(sda);
-            }
-            i2caddr <<= 1;
-            if (cycle >= 16) {
-              m5gfx::pinMode(sda, (cycle == 16) ? m5gfx::pin_mode_t::input : m5gfx::pin_mode_t::output);
-            }
-          }
-        }
-        m5gfx::gpio_hi(sda);  // SDA HIGH = STOP
-        result = result << 1 | nack;
+    bool hit = false;
+    if (m5gfx::i2c::init(probe_i2c_port, sda, scl).has_value())
+    {
+      // クロックが上がらないバス、前の通信の途中でデバイスがデータ線を握っている
+      // バスは、いずれも beginTransaction 側が検出して復旧または中断する。
+      // NACK の場合も beginTransaction 自体は成功を返し (内部で STOP を出して
+      // エラーをラッチする)、そのエラーは endTransaction が報告する。
+      // したがって両方の成功をもって「ACK が返った」と判定する。
+      // 旧実装はプルアップの有無しか見ておらず、デバイスが応答するかは確かめて
+      // いなかった。厳密に ACK を要求するようになったぶん、起動が遅い個体を
+      // 取りこぼす余地ができるので、間を空けて一度だけ試し直す。
+      for (int attempt = 0; attempt < 2 && !hit; ++attempt)
+      {
+        if (attempt) { m5gfx::delay(20); }
+        hit = m5gfx::i2c::beginTransaction(probe_i2c_port, addr, 100000, false).has_value()
+           && m5gfx::i2c::endTransaction(probe_i2c_port).has_value();
       }
+      m5gfx::i2c::release(probe_i2c_port);
     }
     for (auto& backup : pin_backup) {
         backup.restore();
     }
-    return result;
+    return hit;
 #endif
   }
 
@@ -1656,7 +1691,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
 
       if (board == board_t::board_unknown) {
         /// PowerHub ?
-        if (_detect_i2c_device(45, 48, 0x50)) {
+        if (_probe_i2c_addr(45, 48, 0x50)) {
           board = board_t::board_M5PowerHub;
         }
       }
@@ -1665,16 +1700,16 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     case 1: // EFUSE_PKG_VERSION_ESP32S3PICO: // LGA56
     if (board == board_t::board_unknown) {
         /// AtomS3RExt / AtomS3RCam have a BMI270 on the internal I2C bus.
-        if (_detect_i2c_device(45, 0, 0x68)
-         || _detect_i2c_device(45, 0, 0x69)) {
+        if (_probe_i2c_addr(45, 0, 0x68)
+         || _probe_i2c_addr(45, 0, 0x69)) {
           board = board_t::board_M5AtomS3RExt;
         }
         /// Stamp-S3Bat ?
-        else if (_detect_i2c_device(48, 47, 0x6E)) {
+        else if (_probe_i2c_addr(48, 47, 0x6E)) {
           board = board_t::board_M5StampS3Bat;
         }
         /// AtomEchoS3R ?
-        else if(_detect_i2c_device(45, 0, 0x18)) {
+        else if(_probe_i2c_addr(45, 0, 0x18)) {
           board = board_t::board_M5AtomVoiceS3R;
         }
         /// StampS3Mini has no other onboard device that can identify it.

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1368,6 +1368,22 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
   static constexpr gpio_num_t CoreInk_BUTTON_PWR_PIN = GPIO_NUM_27;
 #endif
 
+  /// probe を始める前に一度だけ、デバイスの電源が安定するのを待つ。
+  /// 待ちが要るのは「電源投入から間もない」ことであってアドレスごとの事情ではないので、
+  /// 判定の入口で一度払う。旧実装は最初の probe が常に真を返して連鎖が止まっていたため
+  /// 結果的に 1 回しか待っていなかった。それを意図として書き直したもの。
+  void M5Unified::_wait_i2c_device_power(void)
+  {
+#if !defined(M5UNIFIED_PC_BUILD)
+    static bool waited = false;
+    if (!waited)
+    {
+      waited = true;
+      m5gfx::delay(50);
+    }
+#endif
+  }
+
   bool M5Unified::_probe_i2c_addr(uint8_t sda, uint8_t scl, uint8_t addr)
   {
 #if defined(M5UNIFIED_PC_BUILD)
@@ -1380,13 +1396,14 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     /// 同じスロットを共有しない。
     static constexpr int_fast16_t probe_i2c_port = -2;
 
+    _wait_i2c_device_power();
+
     m5gfx::gpio::pin_backup_t pin_backup[] = { scl, sda };
 
-    // デバイスの電源投入直後の安定待ち。バスは解放した状態で待つ
-    // (SCL を Low に駆動したまま待つと、バスタイムアウトを持つデバイスに対して不正)。
+    // ここでは待たない。電源安定待ちは判定の入口で一度だけ行う (_wait_i2c_device_power)。
+    // アドレスごとに待つと、判定が空振りするたびに数十 ms が起動時間へ積み上がる。
     m5gfx::pinMode(scl, m5gfx::pin_mode_t::input_pullup);
     m5gfx::pinMode(sda, m5gfx::pin_mode_t::input_pullup);
-    m5gfx::delay(50);
 
     // 指定ピンが「外部プルアップの載った I2C バス」かどうかを先に確かめる。
     // ここは I2C ピンとは限らない場所を駆動する機種判別なので、判定を外すと

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1431,8 +1431,11 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     };
     auto bus_check = [&](void) -> uint32_t
     {
-      m5gfx::pinMode(scl, m5gfx::pin_mode_t::output);
-      m5gfx::pinMode(sda, m5gfx::pin_mode_t::output);
+      // ラッチを Low にしてから出力へ切り替える。直前は input_pullup (ラッチ High)
+      // なので、先に出力にすると一瞬 push-pull で High を駆動してしまう。
+      // ここは相手が何か分からないピンなので、High は一度も駆動しない。
+      m5gfx::gpio_lo(scl); m5gfx::pinMode(scl, m5gfx::pin_mode_t::output);
+      m5gfx::gpio_lo(sda); m5gfx::pinMode(sda, m5gfx::pin_mode_t::output);
       return m5gfx::gpio::command(cmd_bus_check_list);
     };
 

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1375,10 +1375,10 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
 #else
     /// アドレスの存在確認はソフトウェア I2C ポートで行う (オープンドレイン駆動で
     /// ACK 競合が起きず、ハードウェアのペリフェラルにも触れない)。
-    /// ポートは M5GFX の autodetect probe と同じ -1 を使う。負ポートは 2 本しかなく、
-    /// probe は使い終わりに release するので逐次実行なら共有できる。2 本目を
-    /// ライブラリ側で占有せず、利用者のソフト I2C バス用に空けておく。
-    static constexpr int_fast16_t probe_i2c_port = -1;
+    /// ポートは M5GFX の autodetect probe (-1) と分ける。ソフト I2C のスロットは
+    /// 所有権を持たず、init が既存の設定を黙って奪う作りなので、ライブラリ同士で
+    /// 同じスロットを共有しない。
+    static constexpr int_fast16_t probe_i2c_port = -2;
 
     m5gfx::gpio::pin_backup_t pin_backup[] = { scl, sda };
 
@@ -1387,25 +1387,6 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     m5gfx::pinMode(scl, m5gfx::pin_mode_t::input_pullup);
     m5gfx::pinMode(sda, m5gfx::pin_mode_t::input_pullup);
     m5gfx::delay(50);
-
-    // 前回の通信の途中で止まっているデバイスに STOP を見せて論理状態を戻す。
-    // START だけで戻らないデバイスが実在する (同ファイルの StampS3/Capsule 判別に
-    // 「STOP を出さないと正しく動作しないデバイスがあった (UnitHEART MAX30100)」の記録がある)。
-    // 線を Low へ駆動するか解放するかの 2 状態しか使わない (High を駆動しない) ので、
-    // デバイスが線を握っていてもパッド同士の衝突にはならない。
-    {
-      auto line_lo = [](uint8_t pin)
-      { m5gfx::gpio_lo(pin); m5gfx::pinMode(pin, m5gfx::pin_mode_t::output); };
-      auto line_hi = [](uint8_t pin)
-      { m5gfx::pinMode(pin, m5gfx::pin_mode_t::input_pullup); };
-      for (int i = 0; i < 8; ++i)
-      {
-        line_lo(scl); m5gfx::delayMicroseconds(5);
-        line_lo(sda); m5gfx::delayMicroseconds(5);
-        line_hi(scl); m5gfx::delayMicroseconds(5);
-        line_hi(sda); m5gfx::delayMicroseconds(5);  // SCL High 中の SDA Low->High = STOP
-      }
-    }
 
     // 指定ピンが「外部プルアップの載った I2C バス」かどうかを先に確かめる。
     // ここは I2C ピンとは限らない場所を駆動する機種判別なので、判定を外すと
@@ -1439,6 +1420,25 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       return false;
     }
 
+    // 前回の通信の途中で止まっているデバイスに STOP を見せて論理状態を戻す。
+    // START だけで戻らないデバイスが実在する (同ファイルの StampS3/Capsule 判別に
+    // 「STOP を出さないと正しく動作しないデバイスがあった (UnitHEART MAX30100)」の記録がある)。
+    // 線を Low へ駆動するか解放するかの 2 状態しか使わない (High を駆動しない) ので、
+    // デバイスが線を握っていてもパッド同士の衝突にはならない。
+    {
+      auto line_lo = [](uint8_t pin)
+      { m5gfx::gpio_lo(pin); m5gfx::pinMode(pin, m5gfx::pin_mode_t::output); };
+      auto line_hi = [](uint8_t pin)
+      { m5gfx::pinMode(pin, m5gfx::pin_mode_t::input_pullup); };
+      for (int i = 0; i < 8; ++i)
+      {
+        line_lo(scl); m5gfx::delayMicroseconds(5);
+        line_lo(sda); m5gfx::delayMicroseconds(5);
+        line_hi(scl); m5gfx::delayMicroseconds(5);
+        line_hi(sda); m5gfx::delayMicroseconds(5);  // SCL High 中の SDA Low->High = STOP
+      }
+    }
+
     bool hit = false;
     if (m5gfx::i2c::init(probe_i2c_port, sda, scl).has_value())
     {
@@ -1447,15 +1447,8 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       // NACK の場合も beginTransaction 自体は成功を返し (内部で STOP を出して
       // エラーをラッチする)、そのエラーは endTransaction が報告する。
       // したがって両方の成功をもって「ACK が返った」と判定する。
-      // 旧実装はプルアップの有無しか見ておらず、デバイスが応答するかは確かめて
-      // いなかった。厳密に ACK を要求するようになったぶん、起動が遅い個体を
-      // 取りこぼす余地ができるので、間を空けて一度だけ試し直す。
-      for (int attempt = 0; attempt < 2 && !hit; ++attempt)
-      {
-        if (attempt) { m5gfx::delay(20); }
-        hit = m5gfx::i2c::beginTransaction(probe_i2c_port, addr, 100000, false).has_value()
-           && m5gfx::i2c::endTransaction(probe_i2c_port).has_value();
-      }
+      hit = m5gfx::i2c::beginTransaction(probe_i2c_port, addr, 100000, false).has_value()
+         && m5gfx::i2c::endTransaction(probe_i2c_port).has_value();
       m5gfx::i2c::release(probe_i2c_port);
     }
     for (auto& backup : pin_backup) {

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1412,9 +1412,20 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       m5gfx::gpio::command_mode_input_pullup  , sda,
       m5gfx::gpio::command_end
     };
-    m5gfx::pinMode(scl, m5gfx::pin_mode_t::output);
-    m5gfx::pinMode(sda, m5gfx::pin_mode_t::output);
-    if (m5gfx::gpio::command(cmd_bus_check_list) != 0x03)
+    auto bus_check = [&](void) -> uint32_t
+    {
+      m5gfx::pinMode(scl, m5gfx::pin_mode_t::output);
+      m5gfx::pinMode(sda, m5gfx::pin_mode_t::output);
+      return m5gfx::gpio::command(cmd_bus_check_list);
+    };
+
+    // 0x02 は「SCL は外部プルアップで戻るのに SDA だけ Low のまま」。前回の通信の
+    // 途中で止まったデバイスがデータ線を握っている典型で (ソフトリセットでは
+    // デバイスの電源が切れないため実際に起きる)、プルアップの無いただの Low ピンとは
+    // このシグネチャで区別できる。この場合だけは STOP を見せて握りを解かせ、
+    // もう一度確かめる。それ以外の不一致は I2C バスではないとみなして即座に帰る。
+    uint32_t check = bus_check();
+    if (check != 0x03 && check != 0x02)
     {
       for (auto& backup : pin_backup) { backup.restore(); }
       return false;
@@ -1437,6 +1448,12 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
         line_hi(scl); m5gfx::delayMicroseconds(5);
         line_hi(sda); m5gfx::delayMicroseconds(5);  // SCL High 中の SDA Low->High = STOP
       }
+    }
+
+    if (check != 0x03 && bus_check() != 0x03)
+    { // 握りが解けなかった。ここから先は probe しても意味がない。
+      for (auto& backup : pin_backup) { backup.restore(); }
+      return false;
     }
 
     bool hit = false;

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1699,18 +1699,26 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
 
     case 1: // EFUSE_PKG_VERSION_ESP32S3PICO: // LGA56
     if (board == board_t::board_unknown) {
+        /// 内部 I2C バス (SDA45/SCL0) に載るデバイスで先に決める。他ピンの probe を
+        /// 間に挟まないので、ここで確定する機種は 48/47 に一切触れずに済む
+        /// (AtomVoiceS3R では GPIO48 が I2S の DOUT)。
+        ///
         /// AtomS3RExt / AtomS3RCam have a BMI270 on the internal I2C bus.
+        /// この 2 機種は基板が共通で、カメラ部がユーザーの扱えるブレッドボードに
+        /// なっているため、内部バスにユーザーのデバイスが載りうる。オンボードで
+        /// 必ず存在する BMI270 を先に見て、後から載ったアドレスに identity を
+        /// 奪われないようにする。
         if (_probe_i2c_addr(45, 0, 0x68)
          || _probe_i2c_addr(45, 0, 0x69)) {
           board = board_t::board_M5AtomS3RExt;
         }
-        /// Stamp-S3Bat ?
+        /// AtomVoiceS3R ?
+        else if (_probe_i2c_addr(45, 0, 0x18)) {
+          board = board_t::board_M5AtomVoiceS3R;
+        }
+        /// Stamp-S3Bat ? (内部バスに何も居なかったときだけ別のピンを触る)
         else if (_probe_i2c_addr(48, 47, 0x6E)) {
           board = board_t::board_M5StampS3Bat;
-        }
-        /// AtomEchoS3R ?
-        else if(_probe_i2c_addr(45, 0, 0x18)) {
-          board = board_t::board_M5AtomVoiceS3R;
         }
         /// StampS3Mini has no other onboard device that can identify it.
         else {

--- a/src/M5Unified.hpp
+++ b/src/M5Unified.hpp
@@ -666,6 +666,9 @@ namespace m5
     board_t _check_boardtype(board_t);
     void _setup_i2c(board_t);
     void _setup_led(board_t);
+    /// probe を始める前に一度だけ、デバイスの電源が安定するのを待つ。
+    static void _wait_i2c_device_power(void);
+
     /// 指定ピンのバス上に、指定した 7bit アドレスのデバイスが居るかを調べる。
     /// (M5GFX にも同名だった _probe_i2c_addr があるが、あちらは複数アドレスを
     ///  ビット列で返す別物。取り違えを避けるため名前を分けている)

--- a/src/M5Unified.hpp
+++ b/src/M5Unified.hpp
@@ -666,7 +666,13 @@ namespace m5
     board_t _check_boardtype(board_t);
     void _setup_i2c(board_t);
     void _setup_led(board_t);
-    bool _detect_i2c_device(uint8_t sda, uint8_t scl, uint8_t addr, const uint8_t* cmd_list=nullptr);
+    /// 指定ピンのバス上に、指定した 7bit アドレスのデバイスが居るかを調べる。
+    /// (M5GFX にも同名だった _probe_i2c_addr があるが、あちらは複数アドレスを
+    ///  ビット列で返す別物。取り違えを避けるため名前を分けている)
+    /// @return true = ACK が返った (デバイスが存在する)。
+    ///         false は「ACK を確認できなかった」であり、不在のほかバスが
+    ///         成立していない場合・probe 用ポートの初期化に失敗した場合を含む。
+    bool _probe_i2c_addr(uint8_t sda, uint8_t scl, uint8_t addr);
 
     static void _setup_pinmap(board_t);
     static bool _speaker_enabled_cb_core2(void* args, bool enabled);


### PR DESCRIPTION
Fixes the Atom VoiceS3R being reported as an AtomS3R-Ext (#330).

Builds on the software I2C fix in M5GFX (m5stack/M5GFX#261), which is what the
probe here now speaks through, and wants the pin restore fix alongside it
(m5stack/M5GFX#262).

## Cause

`_detect_i2c_device()` was not I2C. It made no start condition, clocked every
address bit twice across twenty pulses, and read the ninth bit a millisecond
after the clock had gone back down — long after any device that acknowledged
had released the line. On a bus with pull-ups the reading is high whether or
not the address is there, so what the function returned was the presence of a
pull-up on the pins, and the five call sites read that value as the device
being present.

Every board on this branch has pull-ups on its internal bus, so the first
condition matched on all of them. The chain checks the AtomS3R-Ext BMI270
first, so the Atom VoiceS3R — same package, same internal bus pins, an ES8311
where the other has a BMI270 — came out as an AtomS3R-Ext. That is why none of
its examples work: only board 145 gets the I2S pins and the amplifier callback
for its built-in audio.

The report's workaround of calling `M5.begin()` a second time with
`fallback_board` cannot help: `begin()` returns immediately once the board is
known, and `fallback_board` only applies when detection came back unknown.

## Change

**Probe the address, over the software I2C port.** Open drain, no peripheral
touched, and the acknowledge that actually comes back. The return value now
means what the call sites always read it as.

Pins that carry no pulled-up bus are left alone, using the same test the
display autodetection applies to pins that may not be I2C at all. The one bus
that gets a second chance is the one holding its data line down — the clock
comes back against the internal pull-down while the data line stays low — which
is a device interrupted mid transfer rather than a pin without a pull-up. That
one is offered a stop condition and looked at again; this file already records
a device that needed exactly that (`UnitHEART MAX30100`, in the Capsule branch).
The stop is made by driving low and releasing, never by driving high, and the
lines are parked low before the pins become outputs, so no high is ever driven
into whatever is on the other side.

**Decide the S3PICO boards on their internal bus first.** The three boards
sharing that bus were separated by a probe on another pin pair in between:
BMI270, then the Stamp-S3Bat address on 48 and 47, then the ES8311. The Atom
VoiceS3R drives its speaker out of GPIO48, so a board fully identified by its
own bus was reaching for the I2S data line before it got there. Within the bus
the BMI270 is asked first: the AtomS3R-Ext and the AtomS3RCam are the same
board, and on the Ext the camera end is a small breadboard the owner is free to
wire up, so an address that is not the BMI270 can appear on the internal bus of
a board that is one. The part that is always fitted decides.

**Wait once, not once per address.** Every probe waited 50ms before touching
the pins. The old one always answered on the first address, so that wait was
paid once; an address that now says it is not there would have made it four
times over on a board with nothing on its internal bus. The wait is about how
long ago the board was powered, so it belongs at the entrance to the check.

The function is renamed to `_probe_i2c_addr()`; M5GFX has a function of the old
name with a different contract, and the two are easy to confuse.

## Measured on hardware

Each board was read three ways before `M5.begin()`: a plain bit-banged scan of
the bus, the new probe, and then `M5.getBoard()`.

| Board | On the internal bus | Expected | Reported |
| --- | --- | --- | --- |
| Atom VoiceS3R | `0x18` only (ES8311) | 145 | 145 |
| AtomS3R-Ext | `0x68` only (BMI270) | 143 | 143 |
| AtomS3RCam | `0x68`, camera `0x21` (GC0308) | 144 | 144 |
| AtomS3RCam M12 | `0x68`, camera `0x3C` (OV3660) | 144 | 144 |
| StampS3Mini | a pull-up on one line of the pair, nothing on the other | 155 | 155 |
| M5PowerHub | `0x50` on 45/48 | 146 | 146 |

A full scan of the Atom VoiceS3R internal bus, `0x08` through `0x77`, answers
at `0x18` and nowhere else — no inertial sensor on that bus on this unit. Both
AtomS3RCam variants still reach the camera identification and come out as 144.

One probe went from 49.8ms to 0.31ms on an AtomS3RCam, with the 50ms now spent
once for the whole identification.

Boards outside this branch were run as well, to see that the pin restore fix
underneath does not disturb display autodetection: M5StopWatch (30, 468x468),
Core2 v1.1 (2, 320x240) and PaperS3 (19, 540x960) all come up and keep running.

## Not verified on hardware

**Stamp-S3Bat.** No unit at hand. This branch changes what its detection
depends on: the old code accepted the pull-ups on GPIO 48/47 and never asked
the M5PM1 at `0x6E` for an answer, while this one requires the acknowledge. A
device slow to come up could be missed where it used to be assumed.

## Known, and deliberately left for later

`false` from the probe means "no acknowledge", which covers the address not
being there, the pins carrying no pulled-up bus, and the port failing to open.
The chain reads all of them as absent, so a bus that could not be probed ends
at the last `else` rather than at unknown. Splitting the answer three ways is
the right shape, and is worth doing on its own rather than inside this fix.

The `internal_imu = false` line for the Atom VoiceS3R suggests the board may
carry an inertial sensor that the unit measured here does not have. The
detection order above is chosen so that either answer identifies the board
correctly.
