### PR TITLE
Stop a low charge voltage request from raising the charge voltage

### DIFF
--- a/src/utility/power/AXP192_Class.cpp
+++ b/src/utility/power/AXP192_Class.cpp
@@ -169,17 +169,15 @@ namespace m5
   }
 
   void AXP192_Class::setChargeVoltage(std::uint16_t max_mV)
-  {
-    max_mV = (max_mV / 10) - 410;
-    if (max_mV > 436 - 410) { max_mV = 436 - 410; }
-    static constexpr std::uint8_t table[] =
-      { 415 - 410  /// 4150mV
-      , 420 - 410  /// 4200mV
-      , 436 - 410  /// 4360mV
-      , 255
-      };
-    size_t i = 0;
-    while (table[i] <= max_mV) { ++i; }
+  { /// reg 0x33 bit6:5 selects the target voltage. Compare in millivolts:
+    /// the earlier form subtracted a bias first, which underflowed the
+    /// unsigned argument for anything below the lowest step and then clamped
+    /// to the highest one - a request for less charge voltage produced more.
+    static constexpr std::uint16_t table[] = { 4100, 4150, 4200, 4360 };
+    size_t i = (sizeof(table) / sizeof(table[0])) - 1;
+    /// pick the highest step that does not exceed the request, and the lowest
+    /// step when the request is under all of them.
+    while (i && table[i] > max_mV) { --i; }
 
     std::uint8_t val = 0;
     if (readRegister(0x33, &val, 1))

--- a/src/utility/power/AXP192_Class.hpp
+++ b/src/utility/power/AXP192_Class.hpp
@@ -34,6 +34,11 @@ namespace m5
 
     /// set battery charge voltage
     /// @param max_mV milli volt. (4100 - 4360).
+    /// set the constant-voltage charge target.
+    /// @param max_mV the highest step at or below this value is selected.
+    /// Supported steps are 4100 / 4150 / 4200 / 4360 mV; a request under the
+    /// lowest step selects that step, and one above the highest selects the
+    /// highest.
     void setChargeVoltage(std::uint16_t max_mV);
 
     /// Get whether the battery is currently charging or not.

--- a/src/utility/power/AXP2101_Class.cpp
+++ b/src/utility/power/AXP2101_Class.cpp
@@ -125,11 +125,18 @@ namespace m5
   }
 
   void AXP2101_Class::setChargeVoltage(std::uint16_t max_mV)
-  { /// reg 0x64 selects the constant-voltage target, 1 = 4.0V through 5 = 4.4V.
-    /// There is no step above 4.4V; the earlier table carried one, and a
-    /// request that reached it wrapped the index back to the reserved 0.
-    /// Requests below the lowest step underflowed the unsigned argument and
-    /// landed on the same 0.
+  { /// reg 0x64 selects the constant-voltage target: 1 = 4.0V through 5 = 4.4V,
+    /// with 0 reserved. An early revision of the datasheet also documented a
+    /// 4.6V setting, which later revisions dropped; nothing this library runs
+    /// on carries a cell that charges to 4.6V, so a request that high is held
+    /// at the highest step both revisions agree on rather than sent to a code
+    /// whose meaning depends on the silicon.
+    ///
+    /// The earlier form subtracted a bias from the argument before comparing.
+    /// The argument is unsigned, so a request under the lowest step wrapped
+    /// around and selected code 0, as did a request that reached the 4.6V
+    /// entry - asking for a gentler charge voltage produced either a reserved
+    /// code or the highest voltage, depending on the silicon.
     static constexpr std::uint16_t table[] = { 4000, 4100, 4200, 4350, 4400 };
     size_t i = (sizeof(table) / sizeof(table[0])) - 1;
     /// pick the highest step that does not exceed the request, and the lowest

--- a/src/utility/power/AXP2101_Class.cpp
+++ b/src/utility/power/AXP2101_Class.cpp
@@ -125,22 +125,18 @@ namespace m5
   }
 
   void AXP2101_Class::setChargeVoltage(std::uint16_t max_mV)
-  {
-    max_mV = (max_mV / 10) - 400;
-    if (max_mV > 460 - 400) { max_mV = 460 - 400; }
-    static constexpr std::uint8_t table[] =
-      { 410 - 400  /// 4100mV
-      , 420 - 400  /// 4200mV
-      , 435 - 400  /// 4350mV
-      , 440 - 400  /// 4400mV
-      , 460 - 400  /// 4600mV
-      , 255
-      };
-    size_t i = 0;
-    while (table[i] <= max_mV) { ++i; }
+  { /// reg 0x64 selects the constant-voltage target, 1 = 4.0V through 5 = 4.4V.
+    /// There is no step above 4.4V; the earlier table carried one, and a
+    /// request that reached it wrapped the index back to the reserved 0.
+    /// Requests below the lowest step underflowed the unsigned argument and
+    /// landed on the same 0.
+    static constexpr std::uint16_t table[] = { 4000, 4100, 4200, 4350, 4400 };
+    size_t i = (sizeof(table) / sizeof(table[0])) - 1;
+    /// pick the highest step that does not exceed the request, and the lowest
+    /// step when the request is under all of them.
+    while (i && table[i] > max_mV) { --i; }
 
-    if (++i >= 0b110) { i = 0; }
-    writeRegister8(0x64, i);
+    writeRegister8(0x64, static_cast<std::uint8_t>(i + 1));
   }
 
   std::int8_t AXP2101_Class::getBatteryLevel(void)

--- a/src/utility/power/AXP2101_Class.hpp
+++ b/src/utility/power/AXP2101_Class.hpp
@@ -86,6 +86,11 @@ namespace m5
 
     /// set battery charge voltage
     /// @param max_mV milli volt. (4100 - 4360).
+    /// set the constant-voltage charge target.
+    /// @param max_mV the highest step at or below this value is selected.
+    /// Supported steps are 4000 / 4100 / 4200 / 4350 / 4400 mV; a request under
+    /// the lowest step selects that step, and one above the highest selects
+    /// the highest.
     void setChargeVoltage(std::uint16_t max_mV);
 
     /// @return -1:discharge / 0:standby / 1:charge


### PR DESCRIPTION
### What is wrong

Both `setChargeVoltage` implementations subtracted a bias from the argument before comparing it against their step table:

```cpp
max_mV = (max_mV / 10) - 410;
if (max_mV > 436 - 410) { max_mV = 436 - 410; }
```

The argument is unsigned, so a request below the lowest step wraps around and is then clamped to the *opposite* end of the table. Asking for a gentler charge voltage produces a harsher one:

| request | AXP192 (REG33H[6:5]) | AXP2101 (REG64H) |
|---|---|---|
| 3800 - 4090 mV | **4.36 V** | **code 0** (reserved in current datasheet revisions) |
| 4100 - 4500 mV | correct | correct |
| 4600 mV and above | correct | **code 0** |

A sketch that sets a lower ceiling for a small cell — `M5.Power.setChargeVoltage(4000)` — configures 4.36 V on the AXP192 instead.

The AXP2101 table also carried a 4.6 V entry. The current datasheet revisions document the constant-voltage register as 4.0 V through 4.4 V with code 0 reserved, so a request that reached that entry wrapped the index onto the reserved code as well.

### What changed

Compare in millivolts against the real steps, take the highest step that does not exceed the request, and fall back to the lowest step when the request is under all of them. **Every request inside the supported range keeps its previous result** — only the two broken edges move.

Both headers now state the supported steps and what happens on either side of them, which nothing documented before.

### Notes

- An early AXP2101 datasheet revision assigned code 0 to 4.6 V, while current revisions reserve it. No battery this library runs on charges to 4.6 V, so a request that high is held at the highest step every revision agrees on rather than sent to a code whose meaning depends on the silicon. The comment records this rather than asserting one revision.
- The parameter stays `uint16_t`, so a negative argument still converts to a large positive one and selects the highest step. That is unchanged by this PR and is better addressed where the setter contract itself is revised.
- `setChargeCurrent` has the same shape of problem (a request below the lowest step is raised to it, and on the AXP2101 the 25/50/75 mA steps are unreachable). Left out of this PR deliberately: it changes what `setChargeCurrent(0)` means, which deserves its own discussion.

### Verified on hardware

Register read-back after each request, with the original value restored afterwards:

- **Core2 (AXP192, chip id 0x03)** — 3800 / 4000 / 4090 mV now select 4.10 V where they selected 4.36 V; 4100 / 4150 / 4200 / 4350 / 4360 / 4400 / 4600 / 5000 mV unchanged.
- **Core2 v1.1 (AXP2101, chip id 0x4A)** — 3800 - 4090 mV now select 4.00 V and 4600 mV and above select 4.40 V, where both wrote code 0; 4100 - 4400 mV unchanged.