### PR TITLE
Stop reporting a finished charge as an ongoing one on the IP5306

### DIFF
--- a/src/utility/power/IP5306_Class.cpp
+++ b/src/utility/power/IP5306_Class.cpp
@@ -104,9 +104,30 @@ namespace m5
   }
 
   bool IP5306_Class::isCharging(void)
-  {
+  { /// This needs both of the flags the datasheet describes, not one of them:
+    /// REG_READ0 bit3 tells charging from discharging, and REG_READ1 bit3
+    /// tells whether the cell has already been filled. Only the first was
+    /// read. It stays set once charging is enabled and a supply is present -
+    /// the completed charge included - so a finished charge was reported as an
+    /// ongoing one, as was a board running with no cell installed at all.
+    ///
+    /// The two sit at adjacent addresses but are read separately on purpose.
+    /// The register document only ever shows a single-byte read and nowhere
+    /// states that the address auto-increments, so reading both in one
+    /// transaction would rest on behaviour that is not specified.
+    ///
+    /// Two limits worth knowing. The full flag has no defined reset value, so
+    /// shortly after power-up it can read as full before the charger has
+    /// settled, and nothing here can tell that from a real full charge. And a
+    /// failed read is reported the same way as "not charging", because this
+    /// return type has no room to say that the question could not be answered.
     std::uint8_t val = 0;
-    return (readRegister(REG_READ0, &val, 1)) && (val & 0x08);
+    if (!readRegister(REG_READ0, &val, 1)) { return false; }
+    /// discharging: either charging is disabled or there is no supply
+    if (!(val & 0x08)) { return false; }
+    if (!readRegister(REG_READ1, &val, 1)) { return false; }
+    /// already full, so nothing is going into the cell
+    return !(val & 0x08);
   }
 
   bool IP5306_Class::setPowerBoostKeepOn(bool en) {


### PR DESCRIPTION
`M5.Power.isCharging()` returns true on M5Stack Basic / GRAY / GO / FIRE whenever charging is enabled and a supply is present - including after the cell is already full, and on a board running with no cell installed.

The register document for this part describes two flags: `REG_READ0` bit3 tells charging from discharging, and `REG_READ1` bit3 tells whether the cell has already been filled. Only the first was read, and that one stays set once charging is enabled, so a completed charge kept reading as an ongoing one.

This reads both.

### Measured on a Core BASIC v2.7, all four cases

| condition | 0x70 | 0x71 | before | after |
|---|---|---|---|---|
| supply removed (running on battery) | `16` | `00` | false | false |
| charging | `19` | `70` | true | true |
| charging disabled | `11` | `00` | false | false |
| **charge complete** | `19` | **`A8`** | **true** | **false** |

### Behaviour change

`isCharging()` now returns false once the cell is full, where it used to stay true for as long as a supply was present. Callers that watched for that transition as a sign that external power was lost will see it at full charge instead. The library has no way to express "full" through this return type yet.

### Notes

The two registers sit at adjacent addresses but are read separately on purpose - the register document only ever shows a single-byte read and never states that the address auto-increments.

Known limits, unchanged by this PR: the full flag has no defined reset value, so shortly after power-up it can read as full before the charger has settled; and a failed read is reported the same way as "not charging", because the return type has no room to say the question could not be answered.
