### PR TITLE
Restore GPIO46 after board detection on boards that expose it to the application

### DIFF
--- a/src/M5Unified.hpp
+++ b/src/M5Unified.hpp
@@ -351,7 +351,12 @@ namespace m5
       if (_board != m5gfx::board_t::board_unknown) { return; }
 
 #if defined ( CONFIG_IDF_TARGET_ESP32S3 )
-      // Power Hold pin for Capsule/Dial/DinMeter
+      // Power Hold pin for Capsule/Dial/DinMeter.
+      // Asserted before the board is known (those boards would power off otherwise).
+      // Boards where GPIO46 is exposed to the application (camera VSYNC on CoreS3, camera data on
+      // AtomS3R Cam, header pin on StampS3 / AtomS3R Ext) get the pad restored once the board is
+      // known, see below.
+      m5gfx::gpio::pin_backup_t gpio46_backup(GPIO_NUM_46);
       m5gfx::gpio_hi(GPIO_NUM_46);
       m5gfx::pinMode(GPIO_NUM_46, m5gfx::pin_mode_t::output);
 #endif
@@ -366,9 +371,29 @@ namespace m5
       }
       auto board = _check_boardtype(Display.getBoard());
       // printf("auto detect board:%d\n",board);
-      if (board == board_t::board_unknown) { board = cfg.fallback_board; }
+      bool board_detected = (board != board_t::board_unknown);
+      if (!board_detected) { board = cfg.fallback_board; }
       _board = board;
       _setup_pinmap(board);
+#if defined ( CONFIG_IDF_TARGET_ESP32S3 )
+      // Restore only on boards positively identified as exposing GPIO46 to the application
+      // (camera VSYNC / data, header pin); every other case (power hold, display bus pins
+      // configured by Display.init(), a fallback board) keeps the previous behaviour.
+      switch (board_detected ? board : board_t::board_unknown)
+      {
+      case board_t::board_M5StackCoreS3:
+      case board_t::board_M5StackCoreS3SE:
+      case board_t::board_M5StackChan:
+      case board_t::board_M5AtomS3RCam:
+      case board_t::board_M5AtomS3RExt:
+      case board_t::board_M5StampS3:
+      case board_t::board_M5StampS3Bat:
+        gpio46_backup.restore();
+        break;
+      default:
+        break;
+      }
+#endif
       _setup_i2c(board);
       _setup_led(board);
       if (res && getDisplayCount() == 0) {


### PR DESCRIPTION
## Problem

On ESP32-S3, `M5.begin()` drives GPIO46 high as an output before the board is known, because Capsule / Dial / DinMeter use it as the power hold pin and would power off otherwise. The pin was left as an output on every board afterwards.

On CoreS3 GPIO46 is the camera VSYNC. When `esp_camera_init()` is called before `M5.begin()` (a legitimate order now that the I2C bus is shared with an already opened `i2c_master` bus), the camera stops delivering frames after `M5.begin()`: `cam_hal: Failed to get frame: timeout`, while the sensor stays readable over I2C. Returning GPIO46 to an input makes frames flow again, which pins the cause to the driven output.

## Change

Back up the pad state before asserting the hold, and restore it once the board is positively identified as one that exposes GPIO46 to the application:

- CoreS3 / CoreS3SE / StackChan (camera VSYNC)
- AtomS3R Cam (camera data)
- AtomS3R Ext / StampS3 / StampS3Bat (header pin)

Every other case keeps the previous behaviour on purpose:

- the power hold boards must stay asserted;
- StopWatch / ChainCaptain / PaperS3 / PaperDIY have `Display.init()` configure GPIO46 as a display bus pin after the backup was taken, so an unconditional restore would undo that;
- a board resolved through `cfg.fallback_board` is not restored, because the physical board may still be one that needs the hold;
- Cardputer / PaperMono use GPIO46 as the mic data line, which M5Unified reconfigures itself.

The pin is still driven high for the duration of board detection; this makes the interference finite instead of permanent, it does not remove it.

## Verification

CoreS3 (GC0308), ESP-IDF 5.5.1, esp32-camera 2.1.7, QVGA RGB565 in DRAM:

- `esp_camera_init()` (own bus on GPIO12/11) → `M5.begin()`: before the change frames time out after `M5.begin()`; after the change frames keep streaming, and reading the PMIC through `M5.In_I2C` on the bus opened by esp32-camera works.
- `M5.begin()` → `esp_camera_init()` with `pin_sccb_sda = -1` and `sccb_i2c_port = M5.In_I2C.getPort()`: unchanged, frames stream and the PMIC is read on the shared bus.

Related: #163.
