### PR TITLE
StopWatch: fix the ES8311 gain structure (mic noise/clipping, speaker distortion at high volume)

### DIFF
--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -1289,9 +1289,9 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       2, 0x02, 0x18,  // 0x02 CLOCK_MANAGER/ MULT_PRE=3
       2, 0x0D, 0x01,  // 0x0D SYSTEM/ Power up analog circuitry
       2, 0x0E, 0x02,  // 0x0E SYSTEM/ : Enable analog PGA, enable ADC modulator
-      2, 0x14, 0x10,  // ES8311_ADC_REG14 : select Mic1p-Mic1n / PGA GAIN (minimum)
-      2, 0x17, 0xFF,  // ES8311_ADC_REG17 : ADC_VOLUME (MAXGAIN) // (0xBF == ± 0 dB )
-      2, 0x1C, 0x6A,  // ES8311_ADC_REG1C : ADC Equalizer bypass, cancel DC offset in digital domain
+      2, 0x14, 0x17,  // ES8311_ADC_REG14 : select Mic1p-Mic1n / analog PGA +21 dB (gain code 7, 3 dB/code; SNR plateaus by this level)
+      2, 0x17, 0xCB,  // ES8311_ADC_REG17 : ADC_VOLUME +6 dB (0xBF == 0 dB, 0.5 dB/step)
+      2, 0x1C, 0x64,  // ES8311_ADC_REG1C : ADC EQ bypass, dynamic HPF, HPF stage-2 coeff 4 (cuts sub-200 Hz rumble at the default 16 kHz rate)
       0
     };
     static constexpr const uint8_t disabled_bulk_data[] = {
@@ -1310,7 +1310,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
     { /// 0x17 loses the value a previous setup wrote on any codec reset,
       /// so it witnesses a reset done outside this library: re-arm then.
       uint8_t v = 0;
-      if (!M5.In_I2C.readRegister(es8311_i2c_addr0, 0x17, &v, 1, 100000) || v != 0xFF)
+      if (!M5.In_I2C.readRegister(es8311_i2c_addr0, 0x17, &v, 1, 100000) || v != 0xCB)
       {
         es8311_capture_armed.store(false, std::memory_order_release);
       }

--- a/src/M5Unified.cpp
+++ b/src/M5Unified.cpp
@@ -715,7 +715,7 @@ static constexpr const uint8_t _pin_table_mbus[][31] = {
       2, 0x0D, 0x01,  // 0x0D SYSTEM/ Power up analog circuitry
       2, 0x12, 0x00,  // 0x12 SYSTEM/ power-up DAC - NOT default
       2, 0x13, 0x10,  // 0x13 SYSTEM/ Enable output to HP drive - NOT default
-      2, 0x32, 0xEF,  // 0x32 DAC/ DAC volume (0xBF == ±0 dB )
+      2, 0x32, 0xCB,  // 0x32 DAC/ DAC volume +6 dB (0xBF == 0 dB, 0.5 dB/step). Reaches full-scale at max master volume; higher values clip digitally without adding loudness
       2, 0x37, 0x08,  // 0x37 DAC/ Bypass DAC equalizer - NOT default
       0
     };


### PR DESCRIPTION
## Overview

Fixes the audio gain structure on M5StopWatch (ES8311). Both directions took their gain in the wrong domain, which caused the recording quality issues and the speaker distortion at higher volumes.

## Problems

**Mic (capture)**: the enable sequence used analog PGA 0 dB with +32 dB of ADC digital volume. Digital gain after the ADC amplifies the noise floor together with the signal and clips loud input early, so recordings were noisy (white noise) and sounded flattened/muffled.

**Speaker (playback)**: the enable sequence set the DAC digital volume to +24 dB (reg 0x32 = 0xEF). Digital gain ahead of the DAC cannot raise the full-scale ceiling, so this adds no loudness at all — it only moves the clipping point down. Any sample above 1/16 of full scale clips hard: with `Speaker.setVolume()` above ~64, a sine wave turns into a buzzer-like square wave without getting any louder.

## Changes

Mic enable bulk:
- `0x14`: analog PGA 0 dB → +21 dB (gain code 7; the measured SNR plateaus by this level, limited by the mic element)
- `0x17`: ADC digital volume +32 dB → +6 dB
- `0x1C`: HPF stage-2 coefficient 10 → 4 (the dynamic HPF was already enabled by the old value; the new coefficient cuts sub-200 Hz rumble at the default 16 kHz rate)
- the reset-witness comparison (added in #348) follows the 0x17 bulk value

Speaker enable bulk:
- `0x32`: DAC digital volume +24 dB → +6 dB (0xCB). This value reaches DAC full scale exactly at maximum master volume.

## Measurements

Mic (440 Hz acoustic reference + Goertzel analysis on-device): SNR 14.6 dB → ~19 dB, silence rms 312 → 52.

Speaker (1 kHz tone played on StopWatch, recorded and analyzed by a second device's mic):

- clipping onset by 0x32 value: 0xEF = vol 64–128, 0xDF = 128–192, 0xCF = 192–255, 0xBF = none up to 255
- 0xEF at vol 64 and 0xBF at vol 255 produce the same acoustic level, confirming +24 dB adds no loudness
- with 0xCB the fundamental rises monotonically through the whole volume range (vol 64/128/192/224/255 → relative amplitude 20/100/222/300/380) with no harmonic explosion; the maximum clean output is about twice the old clean ceiling

The #348 recovery matrix (speaker/mic alternating stress, 20 cycles) still passes with these values, and the stock `Basic/Speaker` and `advanced/Mic_FFT` examples were verified by ear on the device.

ChainCaptain shares the same ES8311 register values but is left unchanged: I have no hardware to verify it.
