### PR TITLE
I2C_Class: prefer driver/i2c_master.h over the legacy driver/i2c.h

### DIFF
--- a/src/utility/I2C_Class.hpp
+++ b/src/utility/I2C_Class.hpp
@@ -5,10 +5,10 @@
 #define __M5_I2C_CLASS_H__
 
 #include "m5unified_common.h"
-#if __has_include ( <driver/i2c.h> )
-
-#include <driver/i2c.h>
-
+#if __has_include ( <driver/i2c_master.h> )
+ #include <driver/i2c_master.h>
+#elif __has_include ( <driver/i2c.h> )
+ #include <driver/i2c.h>
 #endif
 
 #include <cstdint>


### PR DESCRIPTION
## Summary

`utility/I2C_Class.hpp` includes the legacy `driver/i2c.h` only to get `i2c_port_t` / `I2C_NUM_x`.
ESP-IDF 6.x marks that header as EOL and emits a `CRITICAL WARNING` pragma on every include. Because `M5Unified.hpp` pulls this header in, the warning repeats for every translation unit of the library (30 times in a plain ESP-IDF 6.1 build). The header is scheduled for removal in IDF v7.

This change includes `driver/i2c_master.h` when it is available (IDF 5.2+) and falls back to `driver/i2c.h` otherwise (IDF 4.4 / Arduino core 2.x).
`i2c_port_t` remains visible to user code through the public API as before; no functional change.

## Verified

- ESP-IDF 6.1 (esp32s3): no `driver/i2c.h` EOL warning, build passes
- Arduino core 2.0.3 (IDF 4.4, fallback path), Arduino core 3.3.9, ESP-IDF 5.5.1: build passes
- Fork CI green on this branch
