### PR TITLE
Add setBufferReleaseCallback to Speaker and Mic

### DIFF
--- a/examples/Advanced/Bluetooth_with_ESP32A2DP/Bluetooth_with_ESP32A2DP.ino
+++ b/examples/Advanced/Bluetooth_with_ESP32A2DP/Bluetooth_with_ESP32A2DP.ino
@@ -2,6 +2,7 @@
 #include <M5UnitLCD.h>
 #include <M5UnitOLED.h>
 #include <M5Unified.h>
+#include <atomic>
 
 /// need ESP32-A2DP library. ( URL : https://github.com/pschatzmann/ESP32-A2DP/ )
 #include <BluetoothA2DPSink.h>
@@ -13,17 +14,25 @@ static constexpr uint8_t m5spk_virtual_channel = 0;
 static constexpr char bt_device_name[] = "ESP32";
 
 
+// zero samples shown while nothing is playing (see getBuffer)
+static const int16_t silent_wave[2048] = {};
+
 class BluetoothA2DPSink_M5Speaker : public BluetoothA2DPSink
 {
 public:
   BluetoothA2DPSink_M5Speaker(m5::Speaker_Class* m5sound, uint8_t virtual_channel = 0)
   : BluetoothA2DPSink()
   {
-    is_i2s_output = false; // I2S control by BluetoothA2DPSink is not required.
+    // The PCM goes to M5.Speaker through audio_data_callback below: no I2S
+    // output by the library. (Same call on the old and the current API.)
+    set_stream_reader(nullptr, false);
   }
 
   // get rawdata buffer for FFT.
-  const int16_t* getBuffer(void) const { return _tri_buf[_export_index]; }
+  /// The most recently queued buffer, for the FFT display only. The storage
+  /// is fixed, so the display may read a frame that is being refilled (torn),
+  /// but never freed memory. Silence (after clear()) is a zero buffer.
+  const int16_t* getBuffer(void) const { return _silent ? silent_wave : _buf[_export_index]; }
 
   const char* getMetaData(size_t id, bool clear_flg = true) { if (clear_flg) { _meta_bits &= ~(1<<id); } return (id < metatext_num) ? _meta_text[id] : nullptr; }
 
@@ -31,20 +40,40 @@ public:
   void clearMetaUpdateInfo(void) { _meta_bits = 0; }
 
   void clear(void)
+  { // The display shows silence from here until audio arrives again. The
+    // buffers themselves are left alone: the speaker task may still read one.
+    _silent = true;
+  }
+
+  // Two buffers used alternately. A buffer is refilled only after the speaker
+  // task has released it, which it reports through setBufferReleaseCallback.
+  static void bufferReleased(void* args, const void* data, uint8_t)
   {
-    for (int i = 0; i < 3; ++i)
-    {
-      if (_tri_buf[i]) { memset(_tri_buf[i], 0, _tri_buf_size[i]); }
-    }
+    auto me = (BluetoothA2DPSink_M5Speaker*)args;
+    // The speaker has finished using this buffer; it can be refilled now.
+    for (int i = 0; i < 2; ++i) { if (data == me->_buf[i]) { me->_busy[i] = false; } }
+  }
+
+  // Volume set from the phone (AVRCP absolute volume, 0-127) drives the
+  // speaker. The library's own software volume is bypassed with the output.
+  static void volumeChanged(int volume)
+  {
+    M5.Speaker.setVolume(volume * 255 / 127);
   }
 
   static constexpr size_t metatext_size = 128;
   static constexpr size_t metatext_num = 3;
 
 protected:
-  int16_t* _tri_buf[3] = { nullptr, nullptr, nullptr };
-  size_t _tri_buf_size[3] = { 0, 0, 0 };
-  size_t _tri_index = 0;
+  // Fixed storage (no reallocation): the addresses the release callback and
+  // the display compare against never change. Half of one A2DP packet fits.
+  static constexpr size_t buf_samples = 2048;
+  int16_t _buf[2][buf_samples];
+  // These flags are shared between tasks. Use std::atomic<bool> here;
+  // plain bool or volatile does not safely share updates between tasks.
+  std::atomic<bool> _busy[2] = { {false}, {false} };
+  std::atomic<bool> _silent { true };
+  size_t _index = 0;
   size_t _export_index = 0;
   char _meta_text[metatext_num][metatext_size];
   uint8_t _meta_bits = 0;
@@ -137,33 +166,40 @@ protected:
     BluetoothA2DPSink::av_hdl_avrc_evt(event, p_param);
   }
 
-  int16_t* get_next_buf(const uint8_t* src_data, uint32_t len)
+  int16_t* get_next_buf(const uint8_t* src_data, uint32_t& len)
   {
-    size_t tri = _tri_index < 2 ? _tri_index + 1 : 0;
-    if (_tri_buf_size[tri] < len)
-    {
-      _tri_buf_size[tri] = len;
-      if (_tri_buf[tri] != nullptr) { heap_caps_free(_tri_buf[tri]); }
-      auto tmp = (int16_t*)heap_caps_malloc(len, MALLOC_CAP_8BIT);
-      _tri_buf[tri] = tmp;
-      if (tmp == nullptr)
-      {
-        _tri_buf_size[tri] = 0;
-        return nullptr;
-      }
-    }
-    memcpy(_tri_buf[tri], src_data, len);
-    _tri_index = tri;
-    return _tri_buf[tri];
+    size_t idx = _index ^ 1;
+    while (_busy[idx]) { vTaskDelay(1); } // wait until the speaker task has released this buffer
+    if (len > sizeof(_buf[idx])) { len = sizeof(_buf[idx]); } // a longer packet than expected: keep what fits
+    memcpy(_buf[idx], src_data, len);
+    _index = idx;
+    return _buf[idx];
+  }
+
+  void play_buf(const int16_t* buf, uint32_t len)
+  {
+    if (len > sizeof(_buf[0])) { len = sizeof(_buf[0]); } // never queue more than the storage holds
+    if (len < 2) { return; }
+    // busy is set before playRaw: the release can only come after the
+    // request is queued. playRaw returns false when nothing was queued.
+    _busy[_index] = true;
+    if (!M5.Speaker.playRaw(buf, len >> 1, _sample_rate, true, 1, m5spk_virtual_channel)) { _busy[_index] = false; }
   }
 
   void audio_data_callback(const uint8_t *data, uint32_t length) override
   {
     // Reduce memory requirements by dividing the received data into the first and second halves.
     length >>= 1;
-    M5.Speaker.playRaw(get_next_buf( data        , length), length >> 1, _sample_rate, true, 1, m5spk_virtual_channel);
-    M5.Speaker.playRaw(get_next_buf(&data[length], length), length >> 1, _sample_rate, true, 1, m5spk_virtual_channel);
-    _export_index = _tri_index;
+    // separate statements: get_next_buf may shorten len, and the order in
+    // which call arguments are evaluated is unspecified.
+    uint32_t len = length;
+    auto buf = get_next_buf(data, len);
+    play_buf(buf, len);
+    len = length;
+    buf = get_next_buf(&data[length], len);
+    play_buf(buf, len);
+    _export_index = _index;
+    _silent = false;
   }
 };
 
@@ -588,6 +624,8 @@ void setup(void)
 
   M5.begin(cfg);
 
+  M5.Speaker.setBufferReleaseCallback(&a2dp_sink, BluetoothA2DPSink_M5Speaker::bufferReleased);
+  a2dp_sink.set_on_volumechange(BluetoothA2DPSink_M5Speaker::volumeChanged);
 
   { /// custom setting
     auto spk_cfg = M5.Speaker.config();
@@ -654,6 +692,7 @@ void loop(void)
     if (v <= 255)
     {
       M5.Speaker.setVolume(v);
+      a2dp_sink.set_volume(v * 127 / 255); // keep the phone's volume display in step
     }
   }
 }

--- a/examples/Advanced/MP3_with_ESP8266Audio/MP3_with_ESP8266Audio.ino
+++ b/examples/Advanced/MP3_with_ESP8266Audio/MP3_with_ESP8266Audio.ino
@@ -11,19 +11,35 @@
 #include <M5UnitLCD.h>
 #include <M5UnitOLED.h>
 #include <M5Unified.h>
+#include <atomic>
+#include <vector>
+#include <algorithm>
 
 /// set M5Speaker virtual channel (0-7)
 static constexpr uint8_t m5spk_virtual_channel = 0;
 
-/// set your mp3 filename
-static constexpr const char* filename[] =
+/// Every *.mp3 in this folder of the card is played, in name order.
+static constexpr const char* mp3_dir = "/mp3";
+static std::vector<String> filename;
+
+static void scanFiles(void)
 {
-  "/mp3/file01.mp3",
-  "/mp3/file02.mp3",
-  "/mp3/file03.mp3",
-  "/mp3/file04.mp3",
-};
-static constexpr const size_t filecount = sizeof(filename) / sizeof(filename[0]);
+  filename.clear();
+  auto dir = SD.open(mp3_dir);
+  if (!dir) { return; }
+  for (auto f = dir.openNextFile(); f; f = dir.openNextFile())
+  {
+    bool is_dir = f.isDirectory();
+    String name = f.name(); // a bare name or a full path, depending on the core version
+    f.close();
+    String lower = name;
+    lower.toLowerCase();
+    if (is_dir || !lower.endsWith(".mp3")) { continue; }
+    filename.push_back(name.startsWith("/") ? name : String(mp3_dir) + "/" + name);
+  }
+  dir.close();
+  std::sort(filename.begin(), filename.end());
+}
 
 class AudioOutputM5Speaker : public AudioOutput
 {
@@ -34,14 +50,26 @@ class AudioOutputM5Speaker : public AudioOutput
       _virtual_ch = virtual_sound_channel;
     }
     virtual ~AudioOutputM5Speaker(void) {};
+    /// Call once after M5.begin() and before anything plays on the speaker
+    /// (the callback may only be registered before the first request).
+    /// Not done in the constructor: at global construction M5 may not exist.
+    void setup(void)
+    {
+      // Buffers are used in rotation and one is refilled only after the
+      // speaker task has released it, which it reports through this callback.
+      // Two would be enough for that handshake; the third keeps one buffer of
+      // slack against decoder and network jitter, as the old three-buffer
+      // form had.
+      _m5sound->setBufferReleaseCallback(this, bufferReleased);
+    }
     virtual bool begin(void) override { return true; }
     virtual bool ConsumeSample(int16_t sample[2]) override
     {
-      if (_tri_buffer_index < tri_buf_size)
+      if (_buffer_index < buf_size)
       {
-        _tri_buffer[_tri_index][_tri_buffer_index  ] = sample[0];
-        _tri_buffer[_tri_index][_tri_buffer_index+1] = sample[1];
-        _tri_buffer_index += 2;
+        _buffer[_index][_buffer_index  ] = sample[0];
+        _buffer[_index][_buffer_index+1] = sample[1];
+        _buffer_index += 2;
 
         return true;
       }
@@ -51,29 +79,52 @@ class AudioOutputM5Speaker : public AudioOutput
     }
     virtual void flush(void) override
     {
-      if (_tri_buffer_index)
+      if (_buffer_index)
       {
-        _m5sound->playRaw(_tri_buffer[_tri_index], _tri_buffer_index, hertz, true, 1, _virtual_ch);
-        _tri_index = _tri_index < 2 ? _tri_index + 1 : 0;
-        _tri_buffer_index = 0;
+        // busy is set before playRaw: the release can only come after the
+        // request is queued. playRaw returns false when nothing was queued.
+        _busy[_index] = true;
+        if (!_m5sound->playRaw(_buffer[_index], _buffer_index, hertz, true, 1, _virtual_ch)) { _busy[_index] = false; }
+        if (++_index >= buf_count) { _index = 0; }
+        _buffer_index = 0;
+        while (_busy[_index]) { vTaskDelay(1); } // wait until the speaker task has released the next buffer
       }
     }
     virtual bool stop(void) override
     {
+      // Let the queued buffers play out rather than cutting them: after the
+      // last release nothing refers to the buffers any more.
       flush();
-      _m5sound->stop(_virtual_ch);
+      for (size_t i = 0; i < buf_count; ++i)
+      {
+        while (_busy[i]) { vTaskDelay(1); }
+      }
       return true;
     }
 
-    const int16_t* getBuffer(void) const { return _tri_buffer[(_tri_index + 2) % 3]; }
+    /// The most recently queued buffer, for the level/FFT display only: the
+    /// producer may start refilling it while it is being read, so a torn
+    /// frame is possible (as with any number of buffers when the reader lags).
+    const int16_t* getBuffer(void) const { return _buffer[(_index + buf_count - 1) % buf_count]; }
 
   protected:
     m5::Speaker_Class* _m5sound;
     uint8_t _virtual_ch;
-    static constexpr size_t tri_buf_size = 1536;
-    int16_t _tri_buffer[3][tri_buf_size];
-    size_t _tri_buffer_index = 0;
-    size_t _tri_index = 0;
+    static constexpr size_t buf_count = 3;
+    static constexpr size_t buf_size = 1536;
+    int16_t _buffer[buf_count][buf_size];
+    // These flags are shared between tasks. Use std::atomic<bool> here;
+    // plain bool or volatile does not safely share updates between tasks.
+    std::atomic<bool> _busy[buf_count] = { {false}, {false}, {false} };
+    size_t _buffer_index = 0;
+    size_t _index = 0;
+
+    static void bufferReleased(void* args, const void* data, uint8_t)
+    {
+      auto me = (AudioOutputM5Speaker*)args;
+      // The speaker has finished using this buffer; it can be refilled now.
+      for (size_t i = 0; i < buf_count; ++i) { if (data == me->_buffer[i]) { me->_busy[i] = false; } }
+    }
 };
 
 
@@ -455,6 +506,7 @@ void setup(void)
   cfg.external_speaker.atomic_spk     = true;
 
   M5.begin(cfg);
+  out.setup();
 
 
   { /// custom setting
@@ -474,7 +526,21 @@ void setup(void)
 
   gfxSetup(&M5.Display);
 
-  play(filename[fileindex]);
+  scanFiles();
+  if (filename.empty())
+  {
+    M5.Display.setCursor(0, 8);
+    M5.Display.printf("no *.mp3 in %s", mp3_dir);
+    for (;;) { M5.delay(1000); }
+  }
+  play(filename[fileindex].c_str());
+}
+
+static void playNext(void)
+{
+  stop();
+  if (++fileindex >= filename.size()) { fileindex = 0; }
+  play(filename[fileindex].c_str());
 }
 
 void loop(void)
@@ -483,7 +549,7 @@ void loop(void)
 
   if (mp3.isRunning())
   {
-    if (!mp3.loop()) { mp3.stop(); }
+    if (!mp3.loop()) { playNext(); } // end of file: on to the next one
   }
   else
   {
@@ -494,9 +560,7 @@ void loop(void)
   if (M5.BtnA.wasClicked())
   {
     M5.Speaker.tone(1000, 100);
-    stop();
-    if (++fileindex >= filecount) { fileindex = 0; }
-    play(filename[fileindex]);
+    playNext();
   }
   else
   if (M5.BtnA.isHolding() || M5.BtnB.isPressed() || M5.BtnC.isPressed())

--- a/examples/Advanced/Speak_with_AquesTalk/Speak_with_AquesTalk.ino
+++ b/examples/Advanced/Speak_with_AquesTalk/Speak_with_AquesTalk.ino
@@ -2,6 +2,7 @@
 #include <M5UnitLCD.h>
 #include <M5UnitOLED.h>
 #include <M5Unified.h>
+#include <atomic>
 
 /// need AquesTalk library. ( URL : https://www.a-quest.com/ )
 #include <aquestalk.h>
@@ -15,19 +16,35 @@ static uint32_t workbuf[AQ_SIZE_WORKBUF];
 static TaskHandle_t task_handle = nullptr;
 volatile bool is_talking = false;
 
+/// Two buffers used alternately. A buffer is refilled only after the speaker
+/// task has released it, which it reports through setBufferReleaseCallback.
+static int16_t wav[2][LEN_FRAME];
+// These flags are shared between tasks. Use std::atomic<bool> here;
+// plain bool or volatile does not safely share updates between tasks.
+static std::atomic<bool> wav_busy[2] = { {false}, {false} };
+
+static void wav_released(void*, const void* data, uint8_t)
+{ // The speaker has finished using this buffer; it can be refilled now.
+  for (int i = 0; i < 2; ++i) { if (data == wav[i]) { wav_busy[i] = false; } }
+}
+
 static void talk_task(void*)
 {
-  int16_t wav[3][LEN_FRAME];
-  int tri_index = 0;
+  int idx = 0;
   for (;;)
   {
     ulTaskNotifyTake( pdTRUE, portMAX_DELAY ); // wait notify
     while (is_talking)
     {
+      while (wav_busy[idx]) { vTaskDelay(1); } // wait until the speaker task has released this buffer
       uint16_t len;
-      if (CAqTkPicoF_SyntheFrame(wav[tri_index], &len)) { is_talking = false; break; }
-      M5.Speaker.playRaw(wav[tri_index], len, 8000, false, 1, m5spk_virtual_channel, false);
-      tri_index = tri_index < 2 ? tri_index + 1 : 0;
+      if (CAqTkPicoF_SyntheFrame(wav[idx], &len)) { is_talking = false; break; }
+      if (len == 0) { continue; }
+      // busy is set before playRaw: the release can only come after the
+      // request is queued. playRaw returns false when nothing was queued.
+      wav_busy[idx] = true;
+      if (!M5.Speaker.playRaw(wav[idx], len, 8000, false, 1, m5spk_virtual_channel, false)) { wav_busy[idx] = false; }
+      idx ^= 1;
     }
   }
 }
@@ -79,6 +96,7 @@ void setup(void)
 
   M5.begin(cfg);
 
+  M5.Speaker.setBufferReleaseCallback(nullptr, wav_released);
   xTaskCreateUniversal(talk_task, "talk_task", 4096, nullptr, 1, &task_handle, APP_CPU_NUM);
 /*
   /// Increasing the sample_rate will improve the sound quality instead of increasing the CPU load.

--- a/examples/Advanced/Speaker_SD_wav_file/Speaker_SD_wav_file.ino
+++ b/examples/Advanced/Speaker_SD_wav_file/Speaker_SD_wav_file.ino
@@ -1,19 +1,24 @@
 #include <SD.h>
 #include <M5Unified.h>
+#include <atomic>
 
 #include <esp_log.h>
 
 static constexpr const gpio_num_t SDCARD_CSPIN = GPIO_NUM_4;
 
-static constexpr const char* files[] = {
-  "/file1.wav",
-  "/file2.wav",
-  "/file3.wav",
-};
-
-static constexpr const size_t buf_num = 3;
+/// Two buffers used alternately. A buffer is refilled only after the speaker
+/// task has released it, which it reports through setBufferReleaseCallback.
+static constexpr const size_t buf_num = 2;
 static constexpr const size_t buf_size = 1024;
 static uint8_t wav_data[buf_num][buf_size];
+// These flags are shared between tasks. Use std::atomic<bool> here;
+// plain bool or volatile does not safely share updates between tasks.
+static std::atomic<bool> wav_busy[buf_num] = { {false}, {false} };
+
+static void wav_released(void*, const void* data, uint8_t)
+{ // The speaker has finished using this buffer; it can be refilled now.
+  for (size_t i = 0; i < buf_num; ++i) { if (data == wav_data[i]) { wav_busy[i] = false; } }
+}
 
 struct __attribute__((packed)) wav_header_t
 {
@@ -97,15 +102,23 @@ static bool playSdWav(const char* filename)
 
   size_t idx = 0;
   while (data_len > 0) {
+    while (wav_busy[idx]) { M5.delay(1); } // wait until the speaker task has released this buffer
     size_t len = data_len < buf_size ? data_len : buf_size;
     len = file.read(wav_data[idx], len);
+    if (flg_16bit) { len &= ~(size_t)1; }
+    if (len == 0) { break; } // file shorter than the data chunk claims
     data_len -= len;
 
+    // busy is set before playRaw: the release can only come after the
+    // request is queued. playRaw returns false when nothing was queued.
+    wav_busy[idx] = true;
+    bool ok;
     if (flg_16bit) {
-      M5.Speaker.playRaw((const int16_t*)wav_data[idx], len >> 1, wav_header.sample_rate, wav_header.channel > 1, 1, 0);
+      ok = M5.Speaker.playRaw((const int16_t*)wav_data[idx], len >> 1, wav_header.sample_rate, wav_header.channel > 1, 1, 0);
     } else {
-      M5.Speaker.playRaw((const uint8_t*)wav_data[idx], len, wav_header.sample_rate, wav_header.channel > 1, 1, 0);
+      ok = M5.Speaker.playRaw((const uint8_t*)wav_data[idx], len, wav_header.sample_rate, wav_header.channel > 1, 1, 0);
     }
+    if (!ok) { wav_busy[idx] = false; }
     idx = idx < (buf_num - 1) ? idx + 1 : 0;
   }
   file.close();
@@ -117,6 +130,7 @@ void setup(void)
 {
   M5.begin();
 
+  M5.Speaker.setBufferReleaseCallback(nullptr, wav_released);
   SD.begin(SDCARD_CSPIN, SPI, 25000000);
 
   // M5.Speaker.setVolume(32);
@@ -124,8 +138,29 @@ void setup(void)
 
 void loop(void)
 {
-  for (auto filename : files) {
-    playSdWav(filename);
+  // Play every *.wav in the root of the card, in directory order.
+  auto dir = SD.open("/");
+  if (!dir) {
+    M5.Display.println("no SD card");
+    M5.delay(1000);
+    return;
+  }
+  size_t played = 0;
+  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    bool is_dir = file.isDirectory();
+    String name = file.name(); // a bare name or a full path, depending on the core version
+    file.close();
+    String lower = name;
+    lower.toLowerCase();
+    if (is_dir || !lower.endsWith(".wav")) { continue; }
+    String path = name.startsWith("/") ? name : "/" + name;
+    M5.Display.println(path);
+    if (playSdWav(path.c_str())) { ++played; }
     M5.delay(500);
+  }
+  dir.close();
+  if (played == 0) {
+    M5.Display.println("no *.wav found");
+    M5.delay(1000);
   }
 }

--- a/examples/Advanced/WebRadio_with_ESP8266Audio/WebRadio_with_ESP8266Audio.ino
+++ b/examples/Advanced/WebRadio_with_ESP8266Audio/WebRadio_with_ESP8266Audio.ino
@@ -1,5 +1,10 @@
+// Fill in here, or pass both from the build (-DWIFI_SSID=\"...\" -DWIFI_PASS=\"...\").
+#ifndef WIFI_SSID
 #define WIFI_SSID "SET YOUR WIFI SSID"
+#endif
+#ifndef WIFI_PASS
 #define WIFI_PASS "SET YOUR WIFI PASS"
+#endif
 
 
 #include <WiFi.h>
@@ -16,22 +21,27 @@
 #include <M5UnitLCD.h>
 #include <M5UnitOLED.h>
 #include <M5Unified.h>
+#include <atomic>
 
 /// set M5Speaker virtual channel (0-7)
 static constexpr uint8_t m5spk_virtual_channel = 0;
 
-/// set web radio station url
+/// set web radio station url (plain http MP3 streams; a station that cannot
+/// be opened is skipped automatically)
 static constexpr const char* station_list[][2] =
 {
-  {"thejazzstream"     , "http://wbgo.streamguys.net/thejazzstream"},
-  {"181-beatles_128k"  , "http://listen.181fm.com/181-beatles_128k.mp3"},
-  {"illstreet-128-mp3" , "http://ice1.somafm.com/illstreet-128-mp3"},
-  {"bootliquor-128-mp3", "http://ice1.somafm.com/bootliquor-128-mp3"},
-  {"dronezone-128-mp3" , "http://ice1.somafm.com/dronezone-128-mp3"},
-  {"Lite Favorites"    , "http://naxos.cdnstream.com:80/1255_128"},
+  {"Radio Paradise"    , "http://stream.radioparadise.com/mp3-128"},
+  {"FIP"               , "http://icecast.radiofrance.fr/fip-midfi.mp3"},
+  {"FIP Jazz"          , "http://icecast.radiofrance.fr/fipjazz-midfi.mp3"},
+  {"France Musique"    , "http://icecast.radiofrance.fr/francemusique-midfi.mp3"},
+  {"181.fm Beatles"    , "http://listen.181fm.com/181-beatles_128k.mp3"},
+  {"181.fm Classical"  , "http://listen.181fm.com/181-classical_128k.mp3"},
+  {"181.fm Jazz Mix"   , "http://listen.181fm.com/181-jazzmix_128k.mp3"},
+  {"KEXP"              , "http://kexp-mp3-128.streamguys1.com/kexp128.mp3"},
+  {"WQXR"              , "http://stream.wqxr.org/wqxr"},
+  {"BBC World Service" , "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service"},
   {"Classic FM"        , "http://media-ice.musicradio.com:80/ClassicFMMP3"},
-  {"MAXXED Out"        , "http://149.56.195.94:8015/steam"},
-  {"Asia Dream"        , "http://igor.torontocast.com:1025/;.-mp3"},
+  {"Lite Favorites"    , "http://naxos.cdnstream.com:80/1255_128"},
 };
 static constexpr const size_t stations = sizeof(station_list) / sizeof(station_list[0]);
 
@@ -44,14 +54,26 @@ class AudioOutputM5Speaker : public AudioOutput
       _virtual_ch = virtual_sound_channel;
     }
     virtual ~AudioOutputM5Speaker(void) {};
+    /// Call once after M5.begin() and before anything plays on the speaker
+    /// (the callback may only be registered before the first request).
+    /// Not done in the constructor: at global construction M5 may not exist.
+    void setup(void)
+    {
+      // Buffers are used in rotation and one is refilled only after the
+      // speaker task has released it, which it reports through this callback.
+      // Two would be enough for that handshake; the third keeps one buffer of
+      // slack against decoder and network jitter, as the old three-buffer
+      // form had.
+      _m5sound->setBufferReleaseCallback(this, bufferReleased);
+    }
     virtual bool begin(void) override { return true; }
     virtual bool ConsumeSample(int16_t sample[2]) override
     {
-      if (_tri_buffer_index < tri_buf_size)
+      if (_buffer_index < buf_size)
       {
-        _tri_buffer[_tri_index][_tri_buffer_index  ] = sample[0];
-        _tri_buffer[_tri_index][_tri_buffer_index+1] = sample[1];
-        _tri_buffer_index += 2;
+        _buffer[_index][_buffer_index  ] = sample[0];
+        _buffer[_index][_buffer_index+1] = sample[1];
+        _buffer_index += 2;
 
         return true;
       }
@@ -61,37 +83,67 @@ class AudioOutputM5Speaker : public AudioOutput
     }
     virtual void flush(void) override
     {
-      if (_tri_buffer_index)
+      if (_buffer_index)
       {
-        _m5sound->playRaw(_tri_buffer[_tri_index], _tri_buffer_index, hertz, true, 1, _virtual_ch);
-        _tri_index = _tri_index < 2 ? _tri_index + 1 : 0;
-        _tri_buffer_index = 0;
+        // busy is set before playRaw: the release can only come after the
+        // request is queued. playRaw returns false when nothing was queued.
+        _busy[_index] = true;
+        if (_m5sound->playRaw(_buffer[_index], _buffer_index, hertz, true, 1, _virtual_ch)) { _frames += _buffer_index / 2; }
+        else { _busy[_index] = false; }
+        if (++_index >= buf_count) { _index = 0; }
+        _buffer_index = 0;
+        while (_busy[_index]) { vTaskDelay(1); } // wait until the speaker task has released the next buffer
         ++_update_count;
       }
     }
     virtual bool stop(void) override
     {
+      // Let the queued buffers play out rather than cutting them: after the
+      // last release nothing refers to the buffers any more.
       flush();
-      _m5sound->stop(_virtual_ch);
-      for (size_t i = 0; i < 3; ++i)
+      for (size_t i = 0; i < buf_count; ++i)
       {
-        memset(_tri_buffer[i], 0, tri_buf_size * sizeof(int16_t));
+        while (_busy[i]) { vTaskDelay(1); }
+      }
+      for (size_t i = 0; i < buf_count; ++i)
+      {
+        memset(_buffer[i], 0, buf_size * sizeof(int16_t));
       }
       ++_update_count;
       return true;
     }
 
-    const int16_t* getBuffer(void) const { return _tri_buffer[(_tri_index + 2) % 3]; }
+    /// The most recently queued buffer, for the level/FFT display only: the
+    /// producer may start refilling it while it is being read, so a torn
+    /// frame is possible (as with any number of buffers when the reader lags).
+    const int16_t* getBuffer(void) const { return _buffer[(_index + buf_count - 1) % buf_count]; }
     const uint32_t getUpdateCount(void) const { return _update_count; }
+    /// stereo frames the speaker accepted so far, and their rate: what has
+    /// actually been played, unlike wall-clock time spent buffering. The
+    /// rate is 0 until the decoder has produced its first sample.
+    uint32_t getFrames(void) const { return _frames; }
+    uint32_t getRate(void) const { return hertz; }
 
   protected:
     m5::Speaker_Class* _m5sound;
     uint8_t _virtual_ch;
-    static constexpr size_t tri_buf_size = 640;
-    int16_t _tri_buffer[3][tri_buf_size];
-    size_t _tri_buffer_index = 0;
-    size_t _tri_index = 0;
+    static constexpr size_t buf_count = 3;
+    static constexpr size_t buf_size = 640;
+    int16_t _buffer[buf_count][buf_size];
+    // These flags are shared between tasks. Use std::atomic<bool> here;
+    // plain bool or volatile does not safely share updates between tasks.
+    std::atomic<bool> _busy[buf_count] = { {false}, {false}, {false} };
+    size_t _buffer_index = 0;
+    size_t _index = 0;
     size_t _update_count = 0;
+    uint32_t _frames = 0;
+
+    static void bufferReleased(void* args, const void* data, uint8_t)
+    {
+      auto me = (AudioOutputM5Speaker*)args;
+      // The speaker has finished using this buffer; it can be refilled now.
+      for (size_t i = 0; i < buf_count; ++i) { if (data == me->_buffer[i]) { me->_busy[i] = false; } }
+    }
 };
 
 
@@ -185,7 +237,13 @@ public:
   }
 };
 
-static constexpr const int preallocateBufferSize = 5 * 1024;
+// Stream buffer: about two seconds of a 128 kbps stream. Playback starts
+// only once it is mostly full and pauses to refill when it runs low, so a
+// network hiccup costs one gap instead of a burst of dropouts.
+static constexpr const int preallocateBufferSize = 32 * 1024;
+static constexpr const int bufferStartLevel = preallocateBufferSize * 3 / 4;
+static constexpr const int bufferLowLevel = preallocateBufferSize / 8;
+static constexpr const uint32_t bufferWaitMs = 3000;
 static constexpr const int preallocateCodecSize = 29192; // MP3 codec max mem needed
 static void* preallocateBuffer = nullptr;
 static void* preallocateCodec = nullptr;
@@ -203,12 +261,13 @@ static int16_t wave_y[WAVE_SIZE];
 static int16_t wave_h[WAVE_SIZE];
 static int16_t raw_data[WAVE_SIZE * 2];
 static int header_height = 0;
-static size_t station_index = 0;
+// Station numbers are shared between the UI and decode tasks, so use std::atomic.
+static std::atomic<size_t> playing_index { 0 }; // station the decode task is on; the UI navigates relative to it
 static char stream_title[128] = { 0 };
 static const char* meta_text[2] = { nullptr, stream_title };
 static const size_t meta_text_num = sizeof(meta_text) / sizeof(meta_text[0]);
 static uint8_t meta_mod_bits = 0;
-static volatile size_t playindex = ~0u;
+static std::atomic<size_t> playindex { ~0u }; // station requested from the UI; ~0u = none
 
 static void MDCallback(void *cbData, const char *type, bool isUnicode, const char *string)
 {
@@ -241,34 +300,142 @@ static void stop(void)
   out.stop();
 }
 
+/// Request a station. Requests are absolute station numbers, so the UI and
+/// the decode task never update a shared counter.
 static void play(size_t index)
 {
-  playindex = index;
+  playindex = index % stations;
 }
+
+/// Ask for the station after `index` from the decode task - unless a
+/// selection made from the UI is already waiting, which wins.
+static void playNext(size_t index)
+{
+  if (++index >= stations) { index = 0; }
+  size_t none = ~0u;
+  playindex.compare_exchange_strong(none, index);
+}
+
+/// Sleep for `ms`, cut short when a station gets selected.
+static void waitUnlessSelected(uint32_t ms)
+{
+  uint32_t start = millis();
+  while (playindex == ~0u && millis() - start < ms) { M5.delay(10); }
+}
+
+/// Keep filling the stream buffer until it holds `level` bytes. Returns false
+/// when a station was selected meanwhile; sets *timed_out when the stream
+/// could not deliver within bufferWaitMs (play on with what there is).
+static bool waitForBuffer(int level, bool* timed_out)
+{
+  *timed_out = false;
+  uint32_t start = millis();
+  while (buff->getFillLevel() < (uint32_t)level)
+  {
+    if (playindex != ~0u) { return false; }
+    if (millis() - start >= bufferWaitMs) { *timed_out = true; break; }
+    buff->loop();
+    M5.delay(1);
+  }
+  return true;
+}
+
+/// A station is counted as working only once this much audio has actually
+/// been played (buffering time does not count); one that fails earlier is
+/// skipped like one that could not be opened.
+static constexpr uint32_t stationOkSeconds = 2;
 
 static void decodeTask(void*)
 {
+  size_t failures = 0;    // stations that failed in a row
+  bool starved = false;   // the stream fell behind: play on, do not wait again until it caught up
+  bool confirmed = false; // the current station has played for stationOkSeconds
+  uint32_t frames_at_start = 0;
   for (;;)
   {
     M5.delay(1);
     if (playindex != ~0u)
     {
-      auto index = playindex;
-      playindex = ~0u;
+      auto index = playindex.exchange(~0u);
+      if (index >= stations) { index = 0; }
       stop();
+      playing_index = index;
+      starved = false;
+      confirmed = false;
       meta_text[0] = station_list[index][0];
       stream_title[0] = 0;
       meta_mod_bits = 3;
       file = new AudioFileSourceICYStream(station_list[index][1]);
-      file->RegisterMetadataCB(MDCallback, (void*)"ICY");
-      buff = new AudioFileSourceBuffer(file, preallocateBuffer, preallocateBufferSize);
-      decoder = new AudioGeneratorMP3(preallocateCodec, preallocateCodecSize);
-      decoder->begin(buff, &out);
+      bool ok = file->isOpen();
+      if (ok)
+      {
+        file->RegisterMetadataCB(MDCallback, (void*)"ICY");
+        buff = new AudioFileSourceBuffer(file, preallocateBuffer, preallocateBufferSize);
+        // The buffer's very first read fills it wholesale (replacing, not
+        // adding to, anything loop() gathered before), so trigger that first,
+        // then let loop() top it up before decoding starts.
+        uint8_t dummy;
+        buff->read(&dummy, 0);
+        bool timed_out;
+        if (!waitForBuffer(bufferStartLevel, &timed_out)) { continue; }
+        starved = timed_out; // a slow stream: do not wait again until it catches up
+        decoder = new AudioGeneratorMP3(preallocateCodec, preallocateCodecSize);
+        ok = decoder->begin(buff, &out); // false if the stream broke meanwhile
+      }
+      if (ok)
+      {
+        frames_at_start = out.getFrames();
+        continue;
+      }
     }
-    if (decoder && decoder->isRunning())
+    else if (decoder && decoder->isRunning())
     {
-      if (!decoder->loop()) { decoder->stop(); }
+      if (!confirmed && out.getRate() != 0
+       && out.getFrames() - frames_at_start >= out.getRate() * stationOkSeconds)
+      {
+        confirmed = true;
+        failures = 0;
+      }
+      uint32_t level = buff->getFillLevel();
+      if (starved)
+      {
+        if (level >= (uint32_t)bufferStartLevel) { starved = false; }
+      }
+      else if (level < (uint32_t)bufferLowLevel)
+      { // running dry: refill before decoding on.
+        bool timed_out;
+        if (!waitForBuffer(bufferStartLevel, &timed_out)) { continue; }
+        starved = timed_out;
+      }
+      if (decoder->loop()) { continue; }
+      decoder->stop();
+      if (confirmed)
+      { // the stream ended or broke after playing: move on to the next station.
+        playNext(playing_index);
+        continue;
+      }
     }
+    else
+    {
+      continue;
+    }
+    // A station that could not be opened, broke during buffering, or stopped
+    // before stationOkSeconds of audio came out: skip it. Once every station failed in a
+    // row, wait a while before going round again. A selection from the UI
+    // cuts the wait short.
+    strncpy(stream_title, "(unavailable, skipping)", sizeof(stream_title) - 1);
+    meta_mod_bits |= 2;
+    stop();
+    if (++failures >= stations)
+    {
+      failures = 0;
+      waitUnlessSelected(5000);
+    }
+    else
+    {
+      waitUnlessSelected(500);
+    }
+    playNext(playing_index);
   }
 }
 
@@ -581,6 +748,7 @@ void setup(void)
   cfg.external_speaker.atomic_spk     = true;
 
   M5.begin(cfg);
+  out.setup();
 
   preallocateBuffer = malloc(preallocateBufferSize);
   preallocateCodec = malloc(preallocateCodecSize);
@@ -604,6 +772,9 @@ void setup(void)
   WiFi.disconnect();
   WiFi.softAPdisconnect(true);
   WiFi.mode(WIFI_STA);
+  // Modem sleep makes the station receive only at DTIM intervals; a stream
+  // then arrives in bursts and the buffer drains between them.
+  WiFi.setSleep(false);
 
 #if defined ( WIFI_SSID ) &&  defined ( WIFI_PASS )
   WiFi.begin(WIFI_SSID, WIFI_PASS);
@@ -620,7 +791,7 @@ void setup(void)
 
   gfxSetup(&M5.Display);
 
-  play(station_index);
+  play(0);
 
   xTaskCreatePinnedToCore(decodeTask, "decodeTask", 4096, nullptr, 1, nullptr, PRO_CPU_NUM);
 }
@@ -653,14 +824,12 @@ void loop(void)
     {
     case 1:
       M5.Speaker.tone(1000, 100);
-      if (++station_index >= stations) { station_index = 0; }
-      play(station_index);
+      play(playing_index + 1);
       break;
 
     case 2:
       M5.Speaker.tone(800, 100);
-      if (station_index == 0) { station_index = stations; }
-      play(--station_index);
+      play(playing_index + stations - 1);
       break;
     }
   }

--- a/examples/Basic/Microphone/Microphone.ino
+++ b/examples/Basic/Microphone/Microphone.ino
@@ -1,6 +1,7 @@
 #include <M5UnitLCD.h>
 #include <M5UnitOLED.h>
 #include <M5Unified.h>
+#include <atomic>
 
 static constexpr const size_t record_number = 256;
 static constexpr const size_t record_length = 200;
@@ -8,9 +9,20 @@ static constexpr const size_t record_size = record_number * record_length;
 static constexpr const size_t record_samplerate = 16000;
 static int16_t prev_y[record_length];
 static int16_t prev_h[record_length];
-static size_t rec_record_idx = 2;
-static size_t draw_record_idx = 0;
+static size_t rec_record_idx = 0;
 static int16_t *rec_data;
+
+/// The block the microphone task has just filled. It reports each finished
+/// record() through setBufferReleaseCallback; the loop draws that block.
+/// (A mailbox holding only the newest block: the display is not required to
+/// show every block.) std::atomic safely passes the pointer and recorded samples
+/// to the loop; a plain or volatile pointer would not provide this synchronization.
+static std::atomic<int16_t*> rec_done { nullptr };
+
+static void rec_released(void*, void* data, size_t)
+{
+  rec_done = (int16_t*)data;
+}
 
 void setup(void)
 {
@@ -37,6 +49,7 @@ void setup(void)
 
   /// Since the microphone and speaker cannot be used at the same time, turn off the speaker here.
   M5.Speaker.end();
+  M5.Mic.setBufferReleaseCallback(nullptr, rec_released);
   M5.Mic.begin();
 }
 
@@ -47,11 +60,17 @@ void loop(void)
   if (M5.Mic.isEnabled())
   {
     static constexpr int shift = 6;
-    auto data = &rec_data[rec_record_idx * record_length];
-    if (M5.Mic.record(data, record_length, record_samplerate))
+    /// record() waits here while both queue slots are taken, so the loop
+    /// runs once per finished block.
+    if (M5.Mic.record(&rec_data[rec_record_idx * record_length], record_length, record_samplerate))
     {
-      data = &rec_data[draw_record_idx * record_length];
+      if (++rec_record_idx >= record_number) { rec_record_idx = 0; }
+    }
 
+    // Take the newest completed block and clear the mailbox in one operation.
+    auto data = rec_done.exchange(nullptr);
+    if (data)
+    {
       int32_t w = M5.Display.width();
       if (w > record_length - 1) { w = record_length - 1; }
       for (int32_t x = 0; x < w; ++x)
@@ -72,9 +91,6 @@ void loop(void)
         M5.Display.writeFastVLine(x, y, h, TFT_WHITE);
       }
       M5.Display.display();
-
-      if (++draw_record_idx >= record_number) { draw_record_idx = 0; }
-      if (++rec_record_idx >= record_number) { rec_record_idx = 0; }
     }
   }
 
@@ -96,6 +112,7 @@ void loop(void)
 
       /// Since the microphone and speaker cannot be used at the same time, turn off the microphone here.
       M5.Mic.end();
+      rec_done = nullptr; // nothing recorded before the restart is shown again
       M5.Speaker.begin();
 
       M5.Display.setCursor(0,0);

--- a/src/utility/Mic_Class.cpp
+++ b/src/utility/Mic_Class.cpp
@@ -788,8 +788,17 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
         dst_remain -= output_num;
         if ((int32_t)dst_remain <= 0)
         {
+          // data has been walked forward while filling: step back over what
+          // was written to hand the caller the pointer they gave record().
+          const size_t total = current_rec->length.load(std::memory_order_relaxed);
+          const size_t written = total - dst_remain; // dst_remain may have wrapped below 0
+          void* released = (uint8_t*)current_rec->data - written * (current_rec->is_16bit ? 2 : 1);
           current_rec->length.store(0, std::memory_order_release);
           xSemaphoreGive(self->_task_semaphore);
+          if (self->_cb_buffer_release)
+          {
+            self->_cb_buffer_release(self->_cb_buffer_release_args, released, total);
+          }
           break;
         }
       }
@@ -859,6 +868,13 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
         _begin_lock.store(false);
         return 0;
       }
+      if (rate != _cfg.sample_rate
+       && xTaskGetCurrentTaskHandle() == _task_handle.load(std::memory_order_acquire))
+      { // the capture task (release callback) cannot rebuild itself: refuse
+        // before the rate is committed, so the live rate stays usable.
+        _begin_lock.store(false);
+        return 0;
+      }
       _cfg.sample_rate = rate;
     }
     if (_begun.load(std::memory_order_acquire) && _rec_sample_rate == _calc_rec_rate())
@@ -879,6 +895,11 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
           // The caller waits outside and retries.
           _begin_lock.store(false);
           return -1;
+        }
+        if (xTaskGetCurrentTaskHandle() == _task_handle.load(std::memory_order_acquire))
+        { // the capture task (release callback) cannot rebuild itself.
+          _begin_lock.store(false);
+          return 0;
         }
         _end_locked();
         _rec_sample_rate = rate;
@@ -1038,17 +1059,23 @@ if (_cfg.pin_bck < 0 || _cfg.pin_ws < 0) {
     // to drain or for the capture side to make progress. The retry has no
     // fairness order - competing callers that keep requesting conflicting
     // sample rates can hold each other off indefinitely.
+    // From the release callback (the capture task itself) nothing may be
+    // waited for: an end() holding _rec_lock waits for this task to exit, and
+    // a free slot only comes from this task. Try once and report.
+    const bool in_task = (xTaskGetCurrentTaskHandle() == _task_handle.load(std::memory_order_acquire));
     for (;;)
     {
       bool zero = false;
       while (!_rec_lock.compare_exchange_strong(zero, true))
       {
+        if (in_task) { return false; }
         zero = false;
         vTaskDelay(1);
       }
       int result = _rec_try_locked(recdata, array_len, flg_16bit, sample_rate, flg_stereo);
       _rec_lock.store(false);
       if (result >= 0) { return result; }
+      if (in_task) { return false; }
       xSemaphoreTake(_task_semaphore, 1);
     }
   }

--- a/src/utility/Mic_Class.hpp
+++ b/src/utility/Mic_Class.hpp
@@ -126,6 +126,29 @@ namespace m5
     /// @return 0=not recording / 1=recording (There's room in the queue) / 2=recording (There's no room in the queue.)
     size_t isRecording(void) const volatile { return ((bool)_rec_info[0].length.load(std::memory_order_acquire)) + ((bool)_rec_info[1].length.load(std::memory_order_acquire)); }
 
+    /// Register a function called when the capture task has filled a buffer
+    /// given to record(): from then on the caller may read or reuse it. Two
+    /// buffers used alternately are enough when the next record() is issued
+    /// from this point.
+    /// @param args passed through as the first argument.
+    /// @param func (args, data, length): data is the pointer given to record(),
+    ///             length its array_len.
+    /// @attention Called from the capture task, not an ISR: keep it short,
+    ///            never block in it, never call begin()/end() from it.
+    /// @attention Requests dropped by end() do not call back. Delivery follows
+    ///            the slot release, so it can arrive after isRecording() has
+    ///            already dropped: track buffers by pointer, not by counting.
+    /// @attention record() may be called from within at the current sample
+    ///            rate: it never waits there and returns false if the queue is
+    ///            full or a begin()/end() is in progress. A different rate is
+    ///            refused there (it would rebuild the calling task) and leaves
+    ///            the current rate untouched.
+    /// @attention Set or clear it only before the first record() or after
+    ///            end() has returned - not merely while isRecording() is 0:
+    ///            the task may still be about to call the previous function,
+    ///            and the function and args are not swapped as one unit.
+    void setBufferReleaseCallback(void* args, void (*func)(void* args, void* data, size_t length)) { _cb_buffer_release_args = args; _cb_buffer_release = func; }
+
     /// set recording sampling rate. Not synchronized: to change the rate
     /// while other tasks may be recording, pass it to record() instead.
     /// @param sample_rate the sampling rate (Hz)
@@ -212,6 +235,8 @@ namespace m5
 
     bool (*_cb_set_enabled)(void* args, bool enabled) = nullptr;
     void* _cb_set_enabled_args = nullptr;
+    void (*_cb_buffer_release)(void* args, void* data, size_t length) = nullptr;
+    void* _cb_buffer_release_args = nullptr;
 
     int32_t _offset = 0;
     /// Written by begin()/end(), polled by the capture task: atomic so the

--- a/src/utility/Speaker_Class.cpp
+++ b/src/utility/Speaker_Class.cpp
@@ -698,6 +698,10 @@ label_next_wav:
             bool clear_idx = ((next_state & wav_state_stop_marker)
                           || !incoming.no_clear_index
                           || (incoming.data != current_wav->data));
+            // the request being replaced (finished or cut) is released below,
+            // once its slot is back with the writers; null once idle (see the
+            // idle path) so a request is never released twice.
+            const void* released = current_wav->data;
             *current_wav = incoming;
             if (next_state & wav_state_stop_marker)
             { // a pure stop: nothing to play. The slot itself is retired
@@ -716,6 +720,10 @@ label_next_wav:
 #if !defined (SDL_h_)
             xSemaphoreGive(self->_task_semaphore);
 #endif
+            if (released && self->_cb_buffer_release)
+            {
+              self->_cb_buffer_release(self->_cb_buffer_release_args, released, ch);
+            }
 
             if (clear_idx)
             {
@@ -734,6 +742,16 @@ label_next_wav:
             xSemaphoreGive(self->_task_semaphore);
 #endif
             self->_play_channel_bits.fetch_and(~(1 << ch));
+            if (current_wav->data)
+            { // finished with nothing queued behind it: release it here and
+              // forget it, so the next adoption does not release it again.
+              // (index is reset below anyway, so no_clear_index is unaffected.)
+              if (self->_cb_buffer_release)
+              {
+                self->_cb_buffer_release(self->_cb_buffer_release_args, current_wav->data, ch);
+              }
+              current_wav->data = nullptr;
+            }
             next_state = ch_info->wavinfo[flip].state.load(std::memory_order_acquire);
             if ((next_state & wav_phase_mask) != wav_phase_published)
             { // nothing to do; a writer caught mid-publish raises the bit itself.
@@ -1003,7 +1021,7 @@ label_continue_sample:
       m5gfx::pinMode(self->_cfg.pin_data_out, m5gfx::pin_mode_t::output);
     }
 #endif
-    self->_task_handle = nullptr;
+    self->_task_handle.store(nullptr, std::memory_order_release);
     vTaskDelete(nullptr);
 #endif
   }
@@ -1040,25 +1058,30 @@ label_continue_sample:
     {
       _task_running = true;
 #if defined (SDL_h_)
-      _task_handle = SDL_CreateThread(reinterpret_cast<SDL_ThreadFunction>(spk_task), "spk_task", this);
-      res = (_task_handle != nullptr);
+      auto handle = SDL_CreateThread(reinterpret_cast<SDL_ThreadFunction>(spk_task), "spk_task", this);
+      _task_handle.store(handle, std::memory_order_release);
+      res = (handle != nullptr);
 #else
       size_t stack_size = 1280 + (_cfg.dma_buf_len * sizeof(uint32_t));
 
 #if portNUM_PROCESSORS > 1
       if (_cfg.task_pinned_core < portNUM_PROCESSORS)
       {
-        res = (pdPASS == xTaskCreatePinnedToCore(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &_task_handle, _cfg.task_pinned_core));
+        TaskHandle_t handle = nullptr;
+        res = (pdPASS == xTaskCreatePinnedToCore(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &handle, _cfg.task_pinned_core));
+        _task_handle.store(handle, std::memory_order_release);
       }
       else
 #endif
       {
-        res = (pdPASS == xTaskCreate(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &_task_handle));
+        TaskHandle_t handle = nullptr;
+        res = (pdPASS == xTaskCreate(spk_task, "spk_task", stack_size, this, _cfg.task_priority, &handle));
+        _task_handle.store(handle, std::memory_order_release);
       }
 #endif
-      // end() takes the driver and the callback back down; it still sees the
-      // class as running, which is what lets it do that.
-      if (!res) { end(); }
+      // the teardown takes the driver and the callback back down; it still
+      // sees the class as running, which is what lets it do that.
+      if (!res) { _end_locked(); }
       else { _begun.store(true, std::memory_order_release); }
     }
     _begin_lock.store(false);
@@ -1068,6 +1091,25 @@ label_continue_sample:
 
   void Speaker_Class::end(void)
   {
+    // Serialized with begin() by the same lock: a teardown must not slip in
+    // between the task being created and its handle being published, or it
+    // would miss the task and the stale handle would be published afterwards.
+    bool zero = false;
+    while (!_begin_lock.compare_exchange_strong(zero, true))
+    {
+      zero = false;
+#if defined (SDL_h_)
+      SDL_Delay(1);
+#else
+      vTaskDelay(1);
+#endif
+    }
+    _end_locked();
+    _begin_lock.store(false);
+  }
+
+  void Speaker_Class::_end_locked(void)
+  {
     _begun.store(false, std::memory_order_release);
     if (_cb_set_enabled) { _cb_set_enabled(_cb_set_enabled_args, false); }
     if (_task_running)
@@ -1076,14 +1118,15 @@ label_continue_sample:
       // already be tearing its handle down. The slots are reset below once
       // the task is gone, which is all the stop would have achieved.
       _task_running = false;
-      if (_task_handle)
+      auto handle = _task_handle.load(std::memory_order_acquire);
+      if (handle)
       {
 #if defined (SDL_h_)
-        SDL_WaitThread(_task_handle, nullptr);
-        _task_handle = nullptr;
+        SDL_WaitThread(handle, nullptr);
+        _task_handle.store(nullptr, std::memory_order_release);
 #else
-        xTaskNotifyGive(_task_handle);
-        do { vTaskDelay(1); } while (_task_handle);
+        xTaskNotifyGive(handle);
+        do { vTaskDelay(1); } while (_task_handle.load(std::memory_order_acquire));
 #endif
       }
     }
@@ -1170,7 +1213,7 @@ label_continue_sample:
                           , std::memory_order_release);
           _play_channel_bits.fetch_or(chmask);
 #if !defined (SDL_h_)
-          xTaskNotifyGive(_task_handle);
+          xTaskNotifyGive(_task_handle.load(std::memory_order_acquire));
 #endif
           return true;
         }
@@ -1183,6 +1226,11 @@ label_continue_sample:
       { // never a turn behind an endless request.
         return false;
       }
+      if (_in_task())
+      { // called from the release callback: only the task frees slots, so
+        // waiting here would be waiting on ourselves.
+        return false;
+      }
 #if !defined (SDL_h_)
       xSemaphoreTake(_task_semaphore, 1);
 #else
@@ -1191,10 +1239,31 @@ label_continue_sample:
     }
   }
 
+  // true while running on the playback task itself (i.e. inside the release
+  // callback), where nothing may be waited for and no lifecycle started.
+  bool Speaker_Class::_in_task(void) const
+  {
+    auto handle = _task_handle.load(std::memory_order_acquire);
+#if defined (SDL_h_)
+    return handle && SDL_ThreadID() == SDL_GetThreadID(handle);
+#else
+    return handle && xTaskGetCurrentTaskHandle() == handle;
+#endif
+  }
+
   bool Speaker_Class::_play_raw(const void* data, size_t array_len, bool flg_16bit, bool flg_signed, float sample_rate, bool flg_stereo, uint32_t repeat_count, int channel, bool stop_current_sound, bool no_clear_index)
   {
-    if (!begin() || (_task_handle == nullptr)) { return true; }
-    if (array_len == 0 || data == nullptr) { return true; }
+    // Only a queued request produces a release callback, so the answer is
+    // false whenever nothing was queued (this used to say true for a speaker
+    // that could not start and for an empty request).
+    if (_in_task())
+    { // from the release callback: an end() may be tearing the task down,
+      // and begin() from here would rebuild it underneath. Never start.
+      if (!_begun.load(std::memory_order_acquire)) { return false; }
+    }
+    else if (!begin()) { return false; }
+    if (_task_handle.load(std::memory_order_acquire) == nullptr) { return false; }
+    if (array_len == 0 || data == nullptr) { return false; }
     size_t ch = (size_t)channel;
     if (ch >= sound_channel_max)
     {

--- a/src/utility/Speaker_Class.hpp
+++ b/src/utility/Speaker_Class.hpp
@@ -116,6 +116,38 @@ namespace m5
     /// @return number of channels that are playing.
     size_t getPlayingChannels(void) const volatile { return __builtin_popcount(_play_channel_bits.load()); }
 
+    /// Register a function called when the playback task has finished reading
+    /// the buffer of a request: from then on the caller may overwrite or free
+    /// the memory that request used. The notice is per request, not per
+    /// memory region: if another request (a queued playRaw() of the same
+    /// data, a re-triggered tone) refers to the same memory, it is still in
+    /// use until that request is released too. Two buffers used alternately
+    /// are enough when the next one is filled from this point (three are
+    /// needed without it).
+    /// @param args passed through as the first argument.
+    /// @param func (args, data, channel): data is the pointer the request was
+    ///             read from - what was given to playRaw()/tone(), and for
+    ///             playWav() the PCM chunk inside the wav, not the wav pointer;
+    ///             channel is the virtual channel it was played on.
+    /// @attention Called from the playback task, not an ISR: keep it short,
+    ///            never block in it, never call begin()/end() from it. The
+    ///            sound itself may still be in the I2S queue - this is buffer
+    ///            release, not end of playback.
+    /// @attention Requests discarded without being played do not call back:
+    ///            a queued one replaced by stop() or stop_current_sound, and
+    ///            everything dropped by end(). The one being played when
+    ///            stop() cuts it does. Delivery follows the slot release, so
+    ///            it can arrive after isPlaying() has already dropped: track
+    ///            buffers by pointer, not by counting.
+    /// @attention play*() may be called from within: it never waits there and
+    ///            returns false if no queue slot is free.
+    /// @attention Set or clear it only before the first play*() or after
+    ///            end() has returned - not merely while the queue looks
+    ///            empty: the task may still be about to call the previous
+    ///            function, and the function and args are not swapped as one
+    ///            unit.
+    void setBufferReleaseCallback(void* args, void (*func)(void* args, const void* data, uint8_t channel)) { _cb_buffer_release_args = args; _cb_buffer_release = func; }
+
     /// sets the output master volume of the sound.
     /// @param master_volume master volume (0~255)
     void setVolume(uint8_t master_volume) { _master_volume = master_volume; }
@@ -172,7 +204,8 @@ namespace m5
     /// @param repeat number of times played repeatedly. (default = 1)
     /// @param channel virtual channel number (If omitted, use an available channel.)
     /// @param stop_current_sound true=start a new output without waiting for the current one to finish.
-    /// @attention If you want to use the data generated at runtime, you can either have three buffers and use them in sequence, or have two buffers and use them alternately, then split them in half and call playRaw twice.
+    /// @attention For data generated at runtime, two buffers used alternately are enough if the next one is filled only after the previous one is released, as reported by setBufferReleaseCallback(). Without it use three buffers in sequence (or, with a single producer and no stop() or stop_current_sound in between, wait for isPlaying(channel) to drop below 2 before refilling).
+    /// @return true if the request was queued; false if not (no free channel, the speaker could not be started, nothing to play). A queued request is reported by setBufferReleaseCallback() unless it is discarded first (see there).
     /// @attention If noise is present in the output sounds, consider increasing the priority of the task that generates the data.
     bool playRaw(const int8_t* raw_data, size_t array_len, uint32_t sample_rate = 44100, bool stereo = false, uint32_t repeat = 1, int channel = -1, bool stop_current_sound = false)
     {
@@ -192,7 +225,8 @@ namespace m5
     /// @param repeat number of times played repeatedly. (default = 1)
     /// @param channel virtual channel number (If omitted, use an available channel.)
     /// @param stop_current_sound true=start a new output without waiting for the current one to finish.
-    /// @attention If you want to use the data generated at runtime, you can either have three buffers and use them in sequence, or have two buffers and use them alternately, then split them in half and call playRaw twice.
+    /// @attention For data generated at runtime, two buffers used alternately are enough if the next one is filled only after the previous one is released, as reported by setBufferReleaseCallback(). Without it use three buffers in sequence (or, with a single producer and no stop() or stop_current_sound in between, wait for isPlaying(channel) to drop below 2 before refilling).
+    /// @return true if the request was queued; false if not (no free channel, the speaker could not be started, nothing to play). A queued request is reported by setBufferReleaseCallback() unless it is discarded first (see there).
     /// @attention If noise is present in the output sounds, consider increasing the priority of the task that generates the data.
     bool playRaw(const uint8_t* raw_data, size_t array_len, uint32_t sample_rate = 44100, bool stereo = false, uint32_t repeat = 1, int channel = -1, bool stop_current_sound = false)
     {
@@ -212,7 +246,8 @@ namespace m5
     /// @param repeat number of times played repeatedly. (default = 1)
     /// @param channel virtual channel number (If omitted, use an available channel.)
     /// @param stop_current_sound true=start a new output without waiting for the current one to finish.
-    /// @attention If you want to use the data generated at runtime, you can either have three buffers and use them in sequence, or have two buffers and use them alternately, then split them in half and call playRaw twice.
+    /// @attention For data generated at runtime, two buffers used alternately are enough if the next one is filled only after the previous one is released, as reported by setBufferReleaseCallback(). Without it use three buffers in sequence (or, with a single producer and no stop() or stop_current_sound in between, wait for isPlaying(channel) to drop below 2 before refilling).
+    /// @return true if the request was queued; false if not (no free channel, the speaker could not be started, nothing to play). A queued request is reported by setBufferReleaseCallback() unless it is discarded first (see there).
     /// @attention If noise is present in the output sounds, consider increasing the priority of the task that generates the data.
     bool playRaw(const int16_t* raw_data, size_t array_len, uint32_t sample_rate = 44100, bool stereo = false, uint32_t repeat = 1, int channel = -1, bool stop_current_sound = false)
     {
@@ -285,7 +320,9 @@ namespace m5
 
     static bool _slot_occupied(const volatile wav_slot_t& slot)
     {
-      uint8_t s = slot.state.load(std::memory_order_relaxed);
+      // acquire: a producer that sees the slot empty may overwrite the buffer
+      // the task has finished reading, so that read must be ordered before.
+      uint8_t s = slot.state.load(std::memory_order_acquire);
       return ((s & wav_phase_mask) != wav_phase_empty) && !(s & wav_state_stop_marker);
     }
 
@@ -308,6 +345,8 @@ namespace m5
     static void spk_task(void* args);
 
     esp_err_t _setup_i2s(void);
+    bool _in_task(void) const;
+    void _end_locked(void);
     bool _play_raw(const void* wav, size_t array_len, bool flg_16bit, bool flg_signed, float sample_rate, bool flg_stereo, uint32_t repeat_count, int channel, bool stop_current_sound, bool no_clear_index);
     bool _set_next_wav(size_t ch, const wav_info_t& wav);
 
@@ -316,6 +355,8 @@ namespace m5
 
     bool (*_cb_set_enabled)(void* args, bool enabled) = nullptr;
     void* _cb_set_enabled_args = nullptr;
+    void (*_cb_buffer_release)(void* args, const void* data, uint8_t channel) = nullptr;
+    void* _cb_buffer_release_args = nullptr;
 
     volatile bool _task_running = false;
     std::atomic<uint16_t> _play_channel_bits = { 0 };
@@ -326,9 +367,11 @@ namespace m5
     /// keys on this, so a caller can never see a half-built port as ready.
     std::atomic<bool> _begun { false };
 #if defined (SDL_h_)
-    SDL_Thread* _task_handle = nullptr;
+    std::atomic<SDL_Thread*> _task_handle { nullptr };
 #else
-    TaskHandle_t _task_handle = nullptr;
+    /// atomic: _in_task() reads it from any caller of play*(), possibly
+    /// while begin() on another task is still creating the task.
+    std::atomic<TaskHandle_t> _task_handle { nullptr };
     volatile SemaphoreHandle_t _task_semaphore = nullptr;
 #endif
   };


### PR DESCRIPTION
### What
A callback that the playback / capture task calls once it has finished with a buffer given to `playRaw()` / `playWav()` / `tone()` or `record()`. From that point the caller may overwrite (Speaker) or read (Mic) the buffer.

```cpp
M5.Speaker.setBufferReleaseCallback(args, [](void* args, const void* data, uint8_t channel) { ... });
M5.Mic.setBufferReleaseCallback(args, [](void* args, void* data, size_t length) { ... });
```

With it, two buffers used alternately are enough for runtime-generated audio. The `playRaw()` notes used to say three were needed; that was conservative even before (waiting for `isPlaying(channel) < 2` gives the same guarantee for a single producer), and the notes now say so.

### Contract (documented in the headers)
- The notice is per request, not per memory region. For `playWav()` the pointer is the PCM chunk inside the wav.
- Requests discarded unplayed do not call back (queued ones replaced by `stop()` / `stop_current_sound`, everything dropped by `end()`); the one being played when `stop()` cuts it does. Delivery follows the slot release, so it can arrive after `isPlaying()` / `isRecording()` already dropped: track buffers by pointer.
- Task context (never an ISR); keep it short, never block, never call `begin()` / `end()` from it. The sound may still be in the I2S queue.
- `play*()` / `record()` may be called from within: they never wait there and return `false` if no slot is free.
- Set or clear only before the first request or after `end()` returned.

### Supporting changes
- `play*()` returns `true` only when the request was queued (it used to return `true` for a speaker that could not start and for an empty request).
- Speaker: task handle is atomic; `end()` is serialized with `begin()` under the same lock.
- `_slot_occupied` loads with acquire (ordering for producers that poll `isPlaying()`).

### Examples
- Speak_with_AquesTalk / Speaker_SD_wav_file / Bluetooth_with_ESP32A2DP: two buffers with atomic busy flags.
- WebRadio / MP3 (ESP8266Audio wrappers): three buffers in rotation with the callback (the third keeps one buffer of slack against decoder / network jitter). Registered from an explicit `setup()` after `M5.begin()`.
- Basic/Microphone: draws the block the callback reports as filled.

Fixes found while verifying the examples on hardware (same commit):
- Bluetooth: the phone's AVRCP volume now drives the speaker and local button changes are reported back; builds on the current ESP32-A2DP (1.8.x) as well as 1.7.x.
- WebRadio: WiFi modem sleep off (with it on, the stream buffer drained at ~2 KB/s while the link could deliver far more), 32 KB stream buffer with pre-buffering and refill, stations that cannot be opened or stop early are skipped, the station list is refreshed (the first entry returned 404), `WIFI_SSID` / `WIFI_PASS` can be passed from the build.
- Speaker_SD_wav_file plays every `*.wav` in the root of the card; MP3_with_ESP8266Audio plays every `*.mp3` in `/mp3`.

### Verification
- ESP32-S3 (StickS3): two-buffer ping-pong driven from the callback, and refilling from inside the callback, 0 overlaps with the task reading the buffer (checked by inspecting the task state during refills); three-buffer and `isPlaying`-wait forms unchanged. Basic/Microphone record / playback on hardware.
- CoreS3 SE: Speaker_SD_wav_file, MP3_with_ESP8266Audio (ESP8266Audio 2.4.1), WebRadio_with_ESP8266Audio (long play without dropouts, station switching).
- Core Basic: Bluetooth_with_ESP32A2DP with ESP32-A2DP 1.7.x on Arduino core 2.x and 1.8.11 on core 3.x, including volume from the phone.
- Not verified: Speak_with_AquesTalk (licensed library not available here); compiles with the same wrapper pattern as the others but was not built.

### Breaking changes
- `playRaw()` / `playWav()` / `tone()` now return `false` when the speaker could not be started or the request is empty (previously `true`).

Fork CI (Arduino / ESP-IDF builds) passed on ainyan03/M5Unified before this PR.
